### PR TITLE
Feat: 사용자는 링크를 등록할 수 있다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/common/Event.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/Event.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.common;
+
+public interface Event {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/common/EventPublisher.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/EventPublisher.java
@@ -1,0 +1,6 @@
+package com.seong.shoutlink.domain.common;
+
+public interface EventPublisher {
+
+    void publishEvent(Event event);
+}

--- a/src/main/java/com/seong/shoutlink/domain/exception/ErrorCode.java
+++ b/src/main/java/com/seong/shoutlink/domain/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     UNAUTHENTICATED("SL101", Constants.UNAUTHORIZED),
     INVALID_ACCESS_TOKEN("SL102", Constants.UNAUTHORIZED),
     EXPIRED_ACCESS_TOKEN("SL103", Constants.UNAUTHORIZED),
+    NOT_FOUND("SL401", Constants.NOT_FOUND),
     DUPLICATE_EMAIL("SL901", Constants.CONFLICT),
     DUPLICATE_NICKNAME("SL902", Constants.BAD_REQUEST);
 
@@ -20,6 +21,7 @@ public enum ErrorCode {
 
         private static final int BAD_REQUEST = 400;
         private static final int UNAUTHORIZED = 401;
+        private static final int NOT_FOUND = 404;
         private static final int CONFLICT = 409;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/Link.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/Link.java
@@ -1,0 +1,17 @@
+package com.seong.shoutlink.domain.link;
+
+import lombok.Getter;
+
+@Getter
+public class Link {
+
+    private Long linkId;
+    private String url;
+    private String description;
+
+
+    public Link(String url, String description) {
+        this.url = url;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/controller/LinkController.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/controller/LinkController.java
@@ -1,0 +1,34 @@
+package com.seong.shoutlink.domain.link.controller;
+
+import com.seong.shoutlink.domain.auth.LoginUser;
+import com.seong.shoutlink.domain.link.controller.request.CreateLinkRequest;
+import com.seong.shoutlink.domain.link.service.LinkService;
+import com.seong.shoutlink.domain.link.service.request.CreateLinkCommand;
+import com.seong.shoutlink.domain.link.service.response.CreateLinkResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class LinkController {
+
+    private final LinkService linkService;
+
+    @PostMapping("/links")
+    public ResponseEntity<CreateLinkResponse> createLink(
+        @LoginUser Long memberId,
+        @Valid @RequestBody CreateLinkRequest request) {
+        CreateLinkResponse response = linkService.createLink(new CreateLinkCommand(
+            memberId,
+            request.url(),
+            request.description()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/controller/request/CreateLinkRequest.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/controller/request/CreateLinkRequest.java
@@ -1,0 +1,10 @@
+package com.seong.shoutlink.domain.link.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateLinkRequest(
+    @NotBlank(message = "링크 url은 필수값입니다.")
+    String url,
+    String description) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
@@ -1,0 +1,32 @@
+package com.seong.shoutlink.domain.link.repository;
+
+import com.seong.shoutlink.domain.link.Link;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LinkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long linkId;
+
+    private String url;
+    private String description;
+
+    private LinkEntity(String url, String description) {
+        this.url = url;
+        this.description = description;
+    }
+
+    public static LinkEntity create(Link link) {
+        return new LinkEntity(link.getUrl(), link.getDescription());
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
@@ -1,0 +1,7 @@
+package com.seong.shoutlink.domain.link.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LinkJpaRepository extends JpaRepository<LinkEntity, Long> {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.seong.shoutlink.domain.link.repository;
+
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.link.service.LinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LinkRepositoryImpl implements LinkRepository {
+
+    private final LinkJpaRepository linkJpaRepository;
+
+    @Override
+    public Long save(Link link) {
+        LinkEntity linkEntity = linkJpaRepository.save(LinkEntity.create(link));
+        return linkEntity.getLinkId();
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
@@ -1,0 +1,8 @@
+package com.seong.shoutlink.domain.link.service;
+
+import com.seong.shoutlink.domain.link.Link;
+
+public interface LinkRepository {
+
+    Long save(Link link);
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
@@ -1,0 +1,30 @@
+package com.seong.shoutlink.domain.link.service;
+
+import com.seong.shoutlink.domain.common.EventPublisher;
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.link.service.event.CreateLinkEvent;
+import com.seong.shoutlink.domain.link.service.request.CreateLinkCommand;
+import com.seong.shoutlink.domain.link.service.response.CreateLinkResponse;
+import com.seong.shoutlink.domain.member.service.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LinkService {
+
+    private final MemberRepository memberRepository;
+    private final LinkRepository linkRepository;
+    private final EventPublisher eventPublisher;
+
+    @Transactional
+    public CreateLinkResponse createLink(CreateLinkCommand command) {
+//        Member member = memberRepository.findById(command.memberId())
+//            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 사용자입니다.", ErrorCode.NOT_FOUND));
+        Link link = new Link(command.url(), command.description());
+        Long linkId = linkRepository.save(link);
+        eventPublisher.publishEvent(new CreateLinkEvent(command.url()));
+        return new CreateLinkResponse(linkId);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateLinkEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateLinkEvent.java
@@ -1,0 +1,7 @@
+package com.seong.shoutlink.domain.link.service.event;
+
+import com.seong.shoutlink.domain.common.Event;
+
+public record CreateLinkEvent(String url) implements Event {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/service/request/CreateLinkCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/request/CreateLinkCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.link.service.request;
+
+public record CreateLinkCommand(Long memberId, String url, String description) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/service/response/CreateLinkResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/response/CreateLinkResponse.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.link.service.response;
+
+public record CreateLinkResponse(Long linkId) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/repository/MemberRepositoryImpl.java
@@ -29,4 +29,10 @@ public class MemberRepositoryImpl implements MemberRepository {
         MemberEntity memberEntity = memberJpaRepository.save(MemberEntity.create(member));
         return memberEntity.getMemberId();
     }
+
+    @Override
+    public Optional<Member> findById(Long memberId) {
+        return memberJpaRepository.findById(memberId)
+            .map(MemberEntity::toDomain);
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/member/service/MemberRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository {
     Optional<Member> findByNickname(String nickname);
 
     Long save(Member member);
+
+    Optional<Member> findById(Long memberId);
 }

--- a/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
@@ -1,0 +1,16 @@
+package com.seong.shoutlink.global.config;
+
+import com.seong.shoutlink.domain.common.EventPublisher;
+import com.seong.shoutlink.global.event.SpringEventPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EventConfig {
+
+    @Bean
+    public EventPublisher eventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        return new SpringEventPublisher(applicationEventPublisher);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/event/SpringEventPublisher.java
+++ b/src/main/java/com/seong/shoutlink/global/event/SpringEventPublisher.java
@@ -1,0 +1,17 @@
+package com.seong.shoutlink.global.event;
+
+import com.seong.shoutlink.domain.common.Event;
+import com.seong.shoutlink.domain.common.EventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+
+@RequiredArgsConstructor
+public class SpringEventPublisher implements EventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publishEvent(Event event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/test/java/com/seong/shoutlink/base/BaseControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/base/BaseControllerTest.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seong.shoutlink.base.BaseControllerTest.BaseControllerConfig;
 import com.seong.shoutlink.domain.auth.JwtProvider;
 import com.seong.shoutlink.domain.auth.service.AuthService;
+import com.seong.shoutlink.domain.link.service.LinkService;
+import com.seong.shoutlink.domain.member.MemberRole;
 import com.seong.shoutlink.fixture.AuthFixture;
 import com.seong.shoutlink.global.auth.authentication.AuthenticationContext;
 import com.seong.shoutlink.global.auth.authentication.JwtAuthenticationProvider;
@@ -52,7 +54,7 @@ public class BaseControllerTest {
     }
 
     protected static final String AUTHORIZATION = "Authorization";
-
+    protected String bearerAccessToken;
     protected MockMvc mockMvc;
 
     @Autowired
@@ -63,6 +65,9 @@ public class BaseControllerTest {
 
     @MockBean
     protected AuthService authService;
+
+    @MockBean
+    protected LinkService linkService;
 
     @BeforeEach
     void setUp(
@@ -75,5 +80,9 @@ public class BaseControllerTest {
                 MockMvcRestDocumentation.documentationConfiguration(documentationContextProvider))
             .addFilter(new CharacterEncodingFilter("UTF-8", true))
             .build();
+
+        this.bearerAccessToken = "Bearer " + AuthFixture.jwtProvider()
+                .createToken(1L, MemberRole.ROLE_USER)
+                .accessToken();
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/common/StubEventPublisher.java
+++ b/src/test/java/com/seong/shoutlink/domain/common/StubEventPublisher.java
@@ -1,0 +1,15 @@
+package com.seong.shoutlink.domain.common;
+
+public class StubEventPublisher implements EventPublisher {
+
+    private int publishEventCount = 0;
+
+    @Override
+    public void publishEvent(Event event) {
+        publishEventCount++;
+    }
+
+    public int getPublishEventCount() {
+        return publishEventCount;
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/link/controller/LinkControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/controller/LinkControllerTest.java
@@ -1,0 +1,54 @@
+package com.seong.shoutlink.domain.link.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.seong.shoutlink.base.BaseControllerTest;
+import com.seong.shoutlink.domain.link.controller.request.CreateLinkRequest;
+import com.seong.shoutlink.domain.link.service.response.CreateLinkResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class LinkControllerTest extends BaseControllerTest {
+
+    @Test
+    @DisplayName("성공: 링크 생성 API 호출 시")
+    void createLink() throws Exception {
+        //given
+        CreateLinkRequest request = new CreateLinkRequest("https://hseong.tistory.com/", "내 블로그");
+        CreateLinkResponse response = new CreateLinkResponse(1L);
+        given(linkService.createLink(any())).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/api/links")
+            .header(AUTHORIZATION, bearerAccessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+
+        //then
+        resultActions.andExpect(status().isCreated())
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION).description("사용자 액세스 토큰")
+                ),
+                requestFields(
+                    fieldWithPath("url").type(JsonFieldType.STRING).description("링크 url"),
+                    fieldWithPath("description").type(JsonFieldType.STRING).description("링크 설명")
+                        .optional()
+                ),
+                responseFields(
+                    fieldWithPath("linkId").type(JsonFieldType.NUMBER).description("생성된 링크 ID")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/link/repository/FakeLinkRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/repository/FakeLinkRepository.java
@@ -1,0 +1,18 @@
+package com.seong.shoutlink.domain.link.repository;
+
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.link.service.LinkRepository;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FakeLinkRepository implements LinkRepository {
+
+    private final Map<Long, Link> memory = new HashMap<>();
+
+    @Override
+    public Long save(Link link) {
+        long nextId = memory.keySet().size() + 1;
+        memory.put(nextId, link);
+        return nextId;
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/service/LinkServiceTest.java
@@ -1,0 +1,63 @@
+package com.seong.shoutlink.domain.link.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.seong.shoutlink.domain.common.StubEventPublisher;
+import com.seong.shoutlink.domain.link.repository.FakeLinkRepository;
+import com.seong.shoutlink.domain.link.service.request.CreateLinkCommand;
+import com.seong.shoutlink.domain.link.service.response.CreateLinkResponse;
+import com.seong.shoutlink.domain.member.repository.StubMemberRepository;
+import com.seong.shoutlink.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LinkServiceTest {
+
+    @Nested
+    @DisplayName("createLink 메서드 호출 시")
+    class CreateLinkTest {
+
+        private LinkService linkService;
+        private StubMemberRepository memberRepository;
+        private FakeLinkRepository linkRepository;
+        private StubEventPublisher eventPublisher;
+
+        @BeforeEach
+        void setUp() {
+            memberRepository = new StubMemberRepository(MemberFixture.member());
+            linkRepository = new FakeLinkRepository();
+            eventPublisher = new StubEventPublisher();
+            linkService = new LinkService(memberRepository, linkRepository, eventPublisher);
+        }
+
+        @Test
+        @DisplayName("성공: 링크 저장됨")
+        void createLink() {
+            //given
+            CreateLinkCommand command = new CreateLinkCommand(1L,
+                "https://hseong.tistory.com/", "내 블로그");
+
+            //when
+            CreateLinkResponse response = linkService.createLink(command);
+
+            //then
+            assertThat(response.linkId()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("성공: 링크 생성 이벤트 발행됨")
+        void createLink_ThenPublishCreateLinkEvent() {
+            //given
+            CreateLinkCommand command = new CreateLinkCommand(1L,
+                "https://hseong.tistory.com/", "내 블로그");
+
+            //when
+            CreateLinkResponse response = linkService.createLink(command);
+
+            //then
+            assertThat(eventPublisher.getPublishEventCount()).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/member/repository/StubMemberRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/member/repository/StubMemberRepository.java
@@ -29,4 +29,9 @@ public final class StubMemberRepository implements MemberRepository {
     public Long save(Member member) {
         return (long) (memory.size() + 1);
     }
+
+    @Override
+    public Optional<Member> findById(Long memberId) {
+        return memory.stream().filter(member -> member.getMemberId().equals(memberId)).findFirst();
+    }
 }

--- a/src/test/java/com/seong/shoutlink/fixture/MemberFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/MemberFixture.java
@@ -1,0 +1,21 @@
+package com.seong.shoutlink.fixture;
+
+import com.seong.shoutlink.domain.auth.FakePasswordEncoder;
+import com.seong.shoutlink.domain.auth.PasswordEncoder;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.MemberRole;
+
+public final class MemberFixture {
+
+    public static final long MEMBER_ID = 1L;
+    public static final String MEMBER_EMAIL = "stub@stub.com";
+    public static final String MEMBER_PASSWORD = "stub123!";
+    public static final String MEMBER_NICKNAME = "stubMember";
+    public static final MemberRole MEMBER_ROLE = MemberRole.ROLE_USER;
+
+    public static Member member() {
+        PasswordEncoder passwordEncoder = new FakePasswordEncoder();
+        return new Member(MEMBER_ID, MEMBER_EMAIL, passwordEncoder.encode(MEMBER_PASSWORD),
+            MEMBER_NICKNAME, MEMBER_ROLE);
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 링크 생성 로직을 구현하였습니다.
- `링크 분류`와 `도메인` 생성은 별도의 이슈를 추가하여 작업합니다.
- `도메인` 생성의 경우 링크 생성 내부에서 이루어질 필요가 없다고 판단하여 링크 생성 이벤트 발행 시 도메인 생성이 이루어질 수 있도록 분리합니다. 이를 위해 이벤트 발행기 인터페이스를 추가하였습니다. 

## 관련 이슈

- close #12 