### PR TITLE
Feat: 사용자는 링크 분류를 조회할 수 있다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/controller/LinkBundleController.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/controller/LinkBundleController.java
@@ -3,12 +3,15 @@ package com.seong.shoutlink.domain.linkbundle.controller;
 import com.seong.shoutlink.domain.auth.LoginUser;
 import com.seong.shoutlink.domain.linkbundle.controller.request.CreateLinkBundleRequest;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleService;
+import com.seong.shoutlink.domain.linkbundle.service.request.FindLinkBundlesCommand;
 import com.seong.shoutlink.domain.linkbundle.service.response.CreateLinkBundleCommand;
 import com.seong.shoutlink.domain.linkbundle.service.response.CreateLinkBundleResponse;
+import com.seong.shoutlink.domain.linkbundle.service.response.FindLinkBundlesResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,5 +34,13 @@ public class LinkBundleController {
                 request.description(),
                 request.isDefault()));
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/link-bundles")
+    public ResponseEntity<FindLinkBundlesResponse> findLinkBundles(
+        @LoginUser Long memberId) {
+        FindLinkBundlesResponse response = linkBundleService.findLinkBundles(
+            new FindLinkBundlesCommand(memberId));
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleJpaRepository.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.linkbundle.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,6 @@ public interface LinkBundleJpaRepository extends JpaRepository<LinkBundleEntity,
     @Query("update LinkBundleEntity lb set lb.isDefault = false"
         + " where lb.isDefault = true and lb.memberId = :memberId")
     void updateDefaultBundleFalse(@Param("memberId") Long memberId);
+
+    List<LinkBundleEntity> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleRepositoryImpl.java
@@ -35,6 +35,8 @@ public class LinkBundleRepositoryImpl implements LinkBundleRepository {
 
     @Override
     public List<LinkBundle> findLinkBundlesThatMembersHave(Member member) {
-        return null;
+        return linkBundleJpaRepository.findAllByMemberId(member.getMemberId()).stream()
+            .map(LinkBundleEntity::toDomain)
+            .toList();
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.seong.shoutlink.domain.linkbundle.repository;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleRepository;
 import com.seong.shoutlink.domain.member.Member;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -30,5 +31,10 @@ public class LinkBundleRepositoryImpl implements LinkBundleRepository {
     public Optional<LinkBundle> findById(Long linkBundleId) {
         return linkBundleJpaRepository.findById(linkBundleId)
             .map(LinkBundleEntity::toDomain);
+    }
+
+    @Override
+    public List<LinkBundle> findLinkBundlesThatMembersHave(Member member) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleRepository.java
@@ -2,6 +2,7 @@ package com.seong.shoutlink.domain.linkbundle.service;
 
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import com.seong.shoutlink.domain.member.Member;
+import java.util.List;
 import java.util.Optional;
 
 public interface LinkBundleRepository {
@@ -11,4 +12,6 @@ public interface LinkBundleRepository {
     void updateDefaultBundleFalse(Member member);
 
     Optional<LinkBundle> findById(Long linkBundleId);
+
+    List<LinkBundle> findLinkBundlesThatMembersHave(Member member);
 }

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleService.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleService.java
@@ -3,10 +3,13 @@ package com.seong.shoutlink.domain.linkbundle.service;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import com.seong.shoutlink.domain.linkbundle.service.request.FindLinkBundlesCommand;
 import com.seong.shoutlink.domain.linkbundle.service.response.CreateLinkBundleCommand;
 import com.seong.shoutlink.domain.linkbundle.service.response.CreateLinkBundleResponse;
+import com.seong.shoutlink.domain.linkbundle.service.response.FindLinkBundlesResponse;
 import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.member.service.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +23,7 @@ public class LinkBundleService {
 
     @Transactional
     public CreateLinkBundleResponse createLinkBundle(CreateLinkBundleCommand command) {
-        Member member = memberRepository.findById(command.memberId())
-            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 사용자입니다.", ErrorCode.NOT_FOUND));
+        Member member = getMember(command.memberId());
         if(command.isDefault()) {
             linkBundleRepository.updateDefaultBundleFalse(member);
         }
@@ -30,5 +32,17 @@ public class LinkBundleService {
             command.isDefault(),
             member);
         return new CreateLinkBundleResponse(linkBundleRepository.save(linkBundle));
+    }
+
+    public FindLinkBundlesResponse findLinkBundles(FindLinkBundlesCommand command) {
+        Member member = getMember(command.memberId());
+        List<LinkBundle> linkBundles
+            = linkBundleRepository.findLinkBundlesThatMembersHave(member);
+        return FindLinkBundlesResponse.from(linkBundles);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 사용자입니다.", ErrorCode.NOT_FOUND));
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/service/request/FindLinkBundlesCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/service/request/FindLinkBundlesCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.linkbundle.service.request;
+
+public record FindLinkBundlesCommand(Long memberId) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/service/response/FindLinkBundleResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/service/response/FindLinkBundleResponse.java
@@ -1,0 +1,16 @@
+package com.seong.shoutlink.domain.linkbundle.service.response;
+
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+
+public record FindLinkBundleResponse(
+    Long linkBundleId,
+    String description,
+    boolean isDefault) {
+
+    public static FindLinkBundleResponse from(LinkBundle linkBundle) {
+        return new FindLinkBundleResponse(
+            linkBundle.getLinkBundleId(),
+            linkBundle.getDescription(),
+            linkBundle.isDefault());
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/service/response/FindLinkBundlesResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/service/response/FindLinkBundlesResponse.java
@@ -1,0 +1,14 @@
+package com.seong.shoutlink.domain.linkbundle.service.response;
+
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import java.util.List;
+
+public record FindLinkBundlesResponse(List<FindLinkBundleResponse> linkBundles) {
+
+    public static FindLinkBundlesResponse from(List<LinkBundle> linkBundles) {
+        List<FindLinkBundleResponse> content = linkBundles.stream()
+            .map(FindLinkBundleResponse::from)
+            .toList();
+        return new FindLinkBundlesResponse(content);
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/linkbundle/controller/LinkBundleControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/linkbundle/controller/LinkBundleControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -13,6 +14,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.seong.shoutlink.base.BaseControllerTest;
 import com.seong.shoutlink.domain.linkbundle.controller.request.CreateLinkBundleRequest;
 import com.seong.shoutlink.domain.linkbundle.service.response.CreateLinkBundleResponse;
+import com.seong.shoutlink.domain.linkbundle.service.response.FindLinkBundleResponse;
+import com.seong.shoutlink.domain.linkbundle.service.response.FindLinkBundlesResponse;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -49,6 +53,37 @@ class LinkBundleControllerTest extends BaseControllerTest {
                 responseFields(
                     fieldWithPath("linkBundleId").type(JsonFieldType.NUMBER)
                         .description("생성된 링크 번들 ID")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 링크 묶음 목록 조회 API 호출 시")
+    void findLinkBundles() throws Exception {
+        //given
+        FindLinkBundlesResponse response = new FindLinkBundlesResponse(List.of(
+            new FindLinkBundleResponse(1L, "기본 분류", true),
+            new FindLinkBundleResponse(2L, "두번째", false)));
+        given(linkBundleService.findLinkBundles(any())).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/link-bundles")
+            .header(AUTHORIZATION, bearerAccessToken));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("linkBundles").type(JsonFieldType.ARRAY).description("링크 묶음 목록"),
+                    fieldWithPath("linkBundles[].linkBundleId").type(JsonFieldType.NUMBER)
+                        .description("링크 묶음 ID"),
+                    fieldWithPath("linkBundles[].description").type(JsonFieldType.STRING)
+                        .description("설명"),
+                    fieldWithPath("linkBundles[].isDefault").type(JsonFieldType.BOOLEAN)
+                        .description("기본 여부")
                 )
             ));
     }

--- a/src/test/java/com/seong/shoutlink/domain/linkbundle/repository/FakeLinkBundleRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/linkbundle/repository/FakeLinkBundleRepository.java
@@ -18,6 +18,13 @@ public class FakeLinkBundleRepository implements LinkBundleRepository {
         }
     }
 
+    public void stub(LinkBundle... linkBundles) {
+        memory.clear();
+        for (LinkBundle linkBundle : linkBundles) {
+            memory.put(getNextId(), linkBundle);
+        }
+    }
+
     @Override
     public Long save(LinkBundle linkBundle) {
         long nextId = getNextId();
@@ -43,6 +50,11 @@ public class FakeLinkBundleRepository implements LinkBundleRepository {
         return memory.values().stream()
             .filter(lb -> lb.getLinkBundleId().equals(linkBundleId))
             .findFirst();
+    }
+
+    @Override
+    public List<LinkBundle> findLinkBundlesThatMembersHave(Member member) {
+        return memory.values().stream().toList();
     }
 
     private long getNextId() {

--- a/src/test/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleServiceTest.java
@@ -5,12 +5,17 @@ import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import com.seong.shoutlink.domain.linkbundle.repository.FakeLinkBundleRepository;
+import com.seong.shoutlink.domain.linkbundle.service.request.FindLinkBundlesCommand;
 import com.seong.shoutlink.domain.linkbundle.service.response.CreateLinkBundleCommand;
 import com.seong.shoutlink.domain.linkbundle.service.response.CreateLinkBundleResponse;
+import com.seong.shoutlink.domain.linkbundle.service.response.FindLinkBundleResponse;
+import com.seong.shoutlink.domain.linkbundle.service.response.FindLinkBundlesResponse;
 import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.member.repository.StubMemberRepository;
 import com.seong.shoutlink.fixture.MemberFixture;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,14 +23,15 @@ import org.junit.jupiter.api.Test;
 
 class LinkBundleServiceTest {
 
+    private StubMemberRepository memberRepository;
+    private FakeLinkBundleRepository linkBundleRepository;
+
     @Nested
     @DisplayName("createLinkBundle 메서드 호출 시")
     class CreateLinkBundleTest {
 
         private Member savedMember;
         private LinkBundleService linkBundleService;
-        private StubMemberRepository memberRepository;
-        private FakeLinkBundleRepository linkBundleRepository;
 
         @BeforeEach
         void setUp() {
@@ -69,6 +75,45 @@ class LinkBundleServiceTest {
                 .isInstanceOf(ShoutLinkException.class)
                 .extracting(e -> ((ShoutLinkException) e).getErrorCode())
                 .isEqualTo(ErrorCode.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("findLinkBundles 메서드 호출 시")
+    class FindLinkBundlesTest {
+
+        private LinkBundleService linkBundleService;
+
+        @BeforeEach
+        void setUp() {
+            memberRepository = new StubMemberRepository();
+            linkBundleRepository = new FakeLinkBundleRepository();
+            linkBundleService = new LinkBundleService(memberRepository, linkBundleRepository);
+        }
+
+        @Test
+        @DisplayName("성공: 링크 번들 목록 조회됨")
+        void findLinkBundles() {
+            //given
+            Member stubMember = MemberFixture.member();
+            memberRepository.stub(stubMember);
+            linkBundleRepository.stub(
+                new LinkBundle(1L, "기본", true, stubMember.getMemberId()),
+                new LinkBundle(2L, "두번째", false, stubMember.getMemberId())
+            );
+            FindLinkBundlesCommand command = new FindLinkBundlesCommand(stubMember.getMemberId());
+
+            //when
+            FindLinkBundlesResponse response = linkBundleService.findLinkBundles(command);
+
+            //then
+            List<FindLinkBundleResponse> linkBundles = response.linkBundles();
+            assertThat(linkBundles)
+                .hasSize(2);
+            assertThat(linkBundles.get(0))
+                .isEqualTo(new FindLinkBundleResponse(1L, "기본", true));
+            assertThat(linkBundles.get(1))
+                .isEqualTo(new FindLinkBundleResponse(2L, "두번째", false));
         }
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/member/repository/StubMemberRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/member/repository/StubMemberRepository.java
@@ -15,6 +15,10 @@ public final class StubMemberRepository implements MemberRepository {
         memory.addAll(Arrays.stream(members).toList());
     }
 
+    public void stub(Member... members) {
+        memory.addAll(Arrays.stream(members).toList());
+    }
+
     @Override
     public Optional<Member> findByEmail(String email) {
         return memory.stream().filter(member -> member.getEmail().equals(email)).findFirst();


### PR DESCRIPTION
## 작업 내용

- 링크 분류 목록 조회 로직을 구현하였습니다.
- 기존 테스트 더블 구현체에 stub() 메서드를 추가해봅니다. 기존에는 생성 시에 객체를 전달했으나 테스트 안에 명시적으로 스터빙을 수행하는 것이 좀 더 명확할 것 같아 변경해봅니다.

## 관련 이슈

- close #22 