### PR TITLE
Chore: 프론트엔드 도메인을 추가한다.

### DIFF
--- a/scripts/data/nginx/backend.conf
+++ b/scripts/data/nginx/backend.conf
@@ -1,6 +1,6 @@
 server {
   listen       80;
-  server_name  shoutlink.me;
+  server_name  api.shoutlink.me;
 
   location / {
         return 301 https://$server_name$request_uri;
@@ -13,7 +13,7 @@ server {
 
 server {
   listen 443 ssl;
-  server_name shoutlink.me;
+  server_name api.shoutlink.me;
 
   location / {
       proxy_pass http://backend;

--- a/scripts/data/nginx/backend.conf
+++ b/scripts/data/nginx/backend.conf
@@ -19,8 +19,8 @@ server {
       proxy_pass http://backend;
   }
 
-  ssl_certificate /etc/letsencrypt/live/shoutlink.me/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/shoutlink.me/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/shoutlink.me-0001/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/shoutlink.me-0001/privkey.pem;
   ssl_prefer_server_ciphers on;
 }
 

--- a/src/main/java/com/seong/shoutlink/global/config/WebConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/WebConfig.java
@@ -22,7 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(
-            new JwtAuthenticationInterceptor(jwtAuthenticationProvider, authenticationContext))
+                new JwtAuthenticationInterceptor(jwtAuthenticationProvider, authenticationContext))
             .order(1)
             .addPathPatterns("/api/**");
     }
@@ -35,7 +35,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-            .allowedOrigins("http://localhost:3000", "https://shoutlink.me")
+            .allowedOrigins(
+                "http://localhost:3000",
+                "https://shoutlink.me",
+                "https://www.shoutlink.me",
+                "https://shout-link-front.vercel.app")
             .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
     }


### PR DESCRIPTION
## 작업 내용

- 프론트엔드를 버셀을 이용해 배포합니다. 따라서 기존 계획과 달리 별도의 컨테이너 설정을 추가하지 않습니다.
- 백엔드 도메인에 `api` 서브 도메인을 추가했습니다. 새로운 인증서 발급으로 nginx 설정을 일부 변경하였습니다.