### PR TITLE
Fix: 허브 링크 번들 목록 조회 영속성 로직을 수정한다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleJpaRepository.java
@@ -1,6 +1,5 @@
 package com.seong.shoutlink.domain.linkbundle.repository;
 
-import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,7 +20,7 @@ public interface LinkBundleJpaRepository extends JpaRepository<LinkBundleEntity,
 
     @Query("select lb from HubLinkBundleEntity lb "
         + "where lb.linkBundleId = :linkBundleId and lb.hubId = :hubId")
-    Optional<LinkBundle> findHubLinkBundle(
+    Optional<LinkBundleEntity> findHubLinkBundle(
         @Param("linkBundleId") Long linkBundleId,
         @Param("hubId") Long hubId);
 

--- a/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/linkbundle/repository/LinkBundleRepositoryImpl.java
@@ -53,7 +53,8 @@ public class LinkBundleRepositoryImpl implements LinkBundleRepository {
 
     @Override
     public Optional<LinkBundle> findHubLinkBundle(Long linkBundleId, Hub hub) {
-        return linkBundleJpaRepository.findHubLinkBundle(linkBundleId, hub.getHubId());
+        return linkBundleJpaRepository.findHubLinkBundle(linkBundleId, hub.getHubId())
+            .map(LinkBundleEntity::toDomain);
     }
 
     @Override


### PR DESCRIPTION
## 작업 내용

- `LinkBundleJpaRepository`의 `findHubLinkBundles()` 메서드의 반환 타입을 `LinkBundle`에서 `LinkBundleEntity`로 수정하였습니다.