### PR TITLE
Feat: 사용자가 링크를 등록하면 도메인 정보를 기록한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ Temporary Items
 .idea/jarRepositories.xml
 .idea/misc.xml
 .idea/vcs.xml
+.idea/modules/shoutlink.iml
+.idea/modules/shoutlink.main.iml
+.idea/modules/shoutlink.test.iml

--- a/src/main/java/com/seong/shoutlink/domain/domain/Domain.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/Domain.java
@@ -1,0 +1,19 @@
+package com.seong.shoutlink.domain.domain;
+
+import lombok.Getter;
+
+@Getter
+public class Domain {
+
+    private Long domainId;
+    private String rootDomain;
+
+    public Domain(String rootDomain) {
+        this(null, rootDomain);
+    }
+
+    public Domain(Long domainId, String rootDomain) {
+        this.domainId = domainId;
+        this.rootDomain = rootDomain;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainEntity.java
@@ -1,0 +1,41 @@
+package com.seong.shoutlink.domain.domain.repository;
+
+import com.seong.shoutlink.domain.common.BaseEntity;
+import com.seong.shoutlink.domain.domain.Domain;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "domain")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DomainEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long domainId;
+    private String rootDomain;
+
+    public DomainEntity(String rootDomain) {
+        this(null, rootDomain);
+    }
+
+    public DomainEntity(Long domainId, String rootDomain) {
+        this.domainId = domainId;
+        this.rootDomain = rootDomain;
+    }
+
+    public static DomainEntity create(Domain domain) {
+        return new DomainEntity(domain.getRootDomain());
+    }
+
+    public Domain toDomain() {
+        return new Domain(domainId, rootDomain);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainJpaRepository.java
@@ -1,0 +1,9 @@
+package com.seong.shoutlink.domain.domain.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DomainJpaRepository extends JpaRepository<DomainEntity, Long> {
+
+    Optional<DomainEntity> findByRootDomain(String rootDomain);
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.seong.shoutlink.domain.domain.repository;
+
+import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DomainRepositoryImpl implements DomainRepository {
+
+    private final DomainJpaRepository domainJpaRepository;
+
+    @Override
+    public Optional<Domain> findByRootDomain(String rootDomain) {
+        return domainJpaRepository.findByRootDomain(rootDomain)
+            .map(DomainEntity::toDomain);
+    }
+
+    @Override
+    public Domain save(Domain domain) {
+        return domainJpaRepository.save(DomainEntity.create(domain))
+            .toDomain();
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
@@ -1,0 +1,11 @@
+package com.seong.shoutlink.domain.domain.service;
+
+import com.seong.shoutlink.domain.domain.Domain;
+import java.util.Optional;
+
+public interface DomainRepository {
+
+    Optional<Domain> findByRootDomain(String rootDomain);
+
+    Domain save(Domain domain);
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
@@ -1,0 +1,37 @@
+package com.seong.shoutlink.domain.domain.service;
+
+import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
+import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
+import com.seong.shoutlink.domain.domain.util.DomainExtractor;
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.link.service.LinkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DomainService {
+
+    private final DomainRepository domainRepository;
+    private final LinkRepository linkRepository;
+
+    @Transactional
+    public UpdateDomainResponse updateDomain(UpdateDomainCommand command) {
+        String rootDomain = DomainExtractor.extractRootDomain(command.url());
+        Domain domain = domainRepository.findByRootDomain(rootDomain)
+            .orElseGet(() -> {
+                Domain newDomain = new Domain(rootDomain);
+                return domainRepository.save(newDomain);
+            });
+        Link link = linkRepository.findById(command.linkId())
+            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 링크입니다.", ErrorCode.NOT_FOUND));
+        linkRepository.updateLinkDomain(link, domain);
+        return new UpdateDomainResponse(domain.getDomainId());
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/request/UpdateDomainCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/request/UpdateDomainCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.domain.service.request;
+
+public record UpdateDomainCommand(Long linkId, String url) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/response/UpdateDomainResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/response/UpdateDomainResponse.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.domain.service.response;
+
+public record UpdateDomainResponse(Long domainId) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/util/DomainExtractor.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/util/DomainExtractor.java
@@ -1,0 +1,81 @@
+package com.seong.shoutlink.domain.domain.util;
+
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DomainExtractor {
+
+    private static final String HTTP = "http";
+    private static final Pattern URL_PATTERN = Pattern.compile(
+        "[-a-zA-Z0-9@:%_\\+.~#?&//=]{2,256}\\.[a-z]{2,4}\\b(\\/[-a-zA-Z0-9가-힣@:%_\\+.~#?&//=]*)?");
+    private static final Set<String> SECOND_DOMAIN = new HashSet<>();
+
+    static {
+        SECOND_DOMAIN.addAll(
+            List.of("co", "ne", "or", "re", "pe", "go", "mil", "ac", "hs", "ms", "es", "sc", "kg"));
+    }
+
+    public static String extractRootDomain(String url) {
+        checkIsUrlPattern(url);
+        String fullDomain = removePath(url);
+        return removeSubDomain(fullDomain);
+    }
+
+    private static void checkIsUrlPattern(String url) {
+        if(URL_PATTERN.matcher(url).matches()) {
+            return;
+        }
+        throw new ShoutLinkException("입력값이 URL 형식이 아닙니다.", ErrorCode.ILLEGAL_ARGUMENT);
+    }
+
+    private static String removePath(String url) {
+        if(url.startsWith(HTTP)) {
+            URI uri = URI.create(url);
+            return uri.getHost();
+        }
+        int firstSlashIndex = url.indexOf("/");
+        if(firstSlashIndex == -1) {
+            return url;
+        }
+        return url.substring(0, firstSlashIndex);
+    }
+
+    private static String removeSubDomain(String fullDomain) {
+        String[] splitDomain = fullDomain.split("\\.");
+        if(hasSecondDomain(splitDomain)) {
+            return makeRootDomain(3, splitDomain);
+        } else {
+            return makeRootDomain(2, splitDomain);
+        }
+    }
+
+    private static boolean hasSecondDomain(String[] splitDomain) {
+        int totalDepth = splitDomain.length;
+        if(totalDepth > 2) {
+            String secondDomain = splitDomain[totalDepth - 2];
+            return SECOND_DOMAIN.stream()
+                .anyMatch(secondDomain::equals);
+        }
+        return false;
+    }
+
+    private static String makeRootDomain(int rootDomainDepth, String[] splitDomain) {
+        int totalDepth = splitDomain.length;
+        StringBuilder domainBuilder = new StringBuilder();
+        for (int depth = rootDomainDepth; depth > 0; depth--) {
+            domainBuilder.append(splitDomain[totalDepth - depth]);
+            if(depth > 1) {
+                domainBuilder.append(".");
+            }
+        }
+        return domainBuilder.toString();
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
@@ -1,6 +1,7 @@
 package com.seong.shoutlink.domain.link.repository;
 
 import com.seong.shoutlink.domain.common.BaseEntity;
+import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
@@ -26,6 +27,7 @@ public class LinkEntity extends BaseEntity {
     private String url;
     private String description;
     private Long linkBundleId;
+    private Long domainId;
 
     private LinkEntity(String url, String description, Long linkBundleId) {
         this.url = url;
@@ -44,5 +46,9 @@ public class LinkEntity extends BaseEntity {
 
     public Link toDomain() {
         return new Link(linkId, url, description);
+    }
+
+    public void updateDomainId(Domain domain) {
+        domainId = domain.getDomainId();
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
@@ -43,7 +43,8 @@ public class LinkRepositoryImpl implements LinkRepository {
 
     @Override
     public void updateLinkDomain(Link link, Domain domain) {
-
+        linkJpaRepository.findById(link.getLinkId())
+            .ifPresent(linkEntity -> linkEntity.updateDomainId(domain));
     }
 
     @Override

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.seong.shoutlink.domain.link.repository;
 
+import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
 import com.seong.shoutlink.domain.link.service.LinkRepository;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -37,5 +39,16 @@ public class LinkRepositoryImpl implements LinkRepository {
             content,
             linkEntityPage.getTotalElements(),
             linkEntityPage.hasNext());
+    }
+
+    @Override
+    public void updateLinkDomain(Link link, Domain domain) {
+
+    }
+
+    @Override
+    public Optional<Link> findById(Long linkId) {
+        return linkJpaRepository.findById(linkId)
+            .map(LinkEntity::toDomain);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
@@ -1,12 +1,19 @@
 package com.seong.shoutlink.domain.link.service;
 
+import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import java.util.Optional;
 
 public interface LinkRepository {
 
     Long save(LinkWithLinkBundle linkWithLinkBundle);
 
     LinkPaginationResult findLinks(LinkBundle linkBundle, int page, int size);
+
+    void updateLinkDomain(Link link, Domain domain);
+
+    Optional<Link> findById(Long linkId);
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
@@ -45,7 +45,7 @@ public class LinkService {
         Link link = new Link(command.url(), command.description());
         LinkWithLinkBundle linkWithLinkBundle = new LinkWithLinkBundle(link, linkBundle);
         Long linkId = linkRepository.save(linkWithLinkBundle);
-        eventPublisher.publishEvent(new CreateLinkEvent(command.url()));
+        eventPublisher.publishEvent(new CreateLinkEvent(linkId, command.url()));
         return new CreateLinkResponse(linkId);
     }
 
@@ -78,7 +78,7 @@ public class LinkService {
         LinkBundle hubLinkBundle = getHubLinkBundle(command.linkBundleId(), hub);
         Link link = new Link(command.url(), command.description());
         Long linkId = linkRepository.save(new LinkWithLinkBundle(link, hubLinkBundle));
-        eventPublisher.publishEvent(new CreateLinkEvent(command.url()));
+        eventPublisher.publishEvent(new CreateLinkEvent(linkId, command.url()));
         return new CreateHubLinkResponse(linkId);
     }
 

--- a/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateLinkEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateLinkEvent.java
@@ -2,6 +2,6 @@ package com.seong.shoutlink.domain.link.service.event;
 
 import com.seong.shoutlink.domain.common.Event;
 
-public record CreateLinkEvent(String url) implements Event {
+public record CreateLinkEvent(Long linkId, String url) implements Event {
 
 }

--- a/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
@@ -1,7 +1,9 @@
 package com.seong.shoutlink.global.config;
 
 import com.seong.shoutlink.domain.common.EventPublisher;
+import com.seong.shoutlink.domain.domain.service.DomainService;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleService;
+import com.seong.shoutlink.global.event.DomainEventListener;
 import com.seong.shoutlink.global.event.LinkBundleEventListener;
 import com.seong.shoutlink.global.event.SpringEventPublisher;
 import org.springframework.context.ApplicationEventPublisher;
@@ -19,5 +21,10 @@ public class EventConfig {
     @Bean
     public LinkBundleEventListener springEventListener(LinkBundleService linkBundleService) {
         return new LinkBundleEventListener(linkBundleService);
+    }
+
+    @Bean
+    public DomainEventListener domainEventListener(DomainService domainService) {
+        return new DomainEventListener(domainService);
     }
 }

--- a/src/main/java/com/seong/shoutlink/global/event/DomainEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/DomainEventListener.java
@@ -1,0 +1,21 @@
+package com.seong.shoutlink.global.event;
+
+import com.seong.shoutlink.domain.domain.service.DomainService;
+import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
+import com.seong.shoutlink.domain.link.service.event.CreateLinkEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+public class DomainEventListener {
+
+    private final DomainService domainService;
+
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateDomainInfo(CreateLinkEvent event) {
+        domainService.updateDomain(new UpdateDomainCommand(event.linkId(), event.url()));
+    }
+}

--- a/src/test/java/com/seong/shoutlink/base/DatabaseCleaner.java
+++ b/src/test/java/com/seong/shoutlink/base/DatabaseCleaner.java
@@ -1,7 +1,6 @@
 package com.seong.shoutlink.base;
 
-import com.seong.shoutlink.domain.linkbundle.repository.HubLinkBundleEntity;
-import com.seong.shoutlink.domain.linkbundle.repository.MemberLinkBundleEntity;
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Table;
 import jakarta.persistence.metamodel.Type;
@@ -22,10 +21,7 @@ public class DatabaseCleaner {
             .getEntities()
             .stream()
             .map(Type::getJavaType)
-            .filter(j ->
-                !(j.isAssignableFrom(HubLinkBundleEntity.class)
-                    || j.isAssignableFrom(MemberLinkBundleEntity.class))
-            )
+            .filter(j -> !j.isAnnotationPresent(DiscriminatorValue.class))
             .map(javaType -> javaType.getAnnotation(Table.class))
             .map(Table::name)
             .toList();

--- a/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
@@ -1,0 +1,34 @@
+package com.seong.shoutlink.domain.domain.repository;
+
+import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class StubDomainRepository implements DomainRepository {
+
+    private final Map<Long, Domain> memory = new HashMap<>();
+
+    public void stub(Domain domain) {
+        memory.put(nextId(), domain);
+    }
+
+    @Override
+    public Optional<Domain> findByRootDomain(String rootDomain) {
+        return memory.values().stream()
+            .filter(domain -> domain.getRootDomain().equals(rootDomain))
+            .findFirst();
+    }
+
+    @Override
+    public Domain save(Domain domain) {
+        Long domainId = nextId();
+        memory.put(domainId, domain);
+        return new Domain(domainId, domain.getRootDomain());
+    }
+
+    private Long nextId() {
+        return (long) (memory.size() + 1);
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
@@ -1,0 +1,85 @@
+package com.seong.shoutlink.domain.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.domain.repository.StubDomainRepository;
+import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
+import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.link.repository.FakeLinkRepository;
+import com.seong.shoutlink.fixture.DomainFixture.DomainFixture;
+import com.seong.shoutlink.fixture.LinkFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DomainServiceTest {
+
+    StubDomainRepository domainRepository;
+    FakeLinkRepository linkRepository;
+    DomainService domainService;
+
+    @Nested
+    @DisplayName("updateDomain 메서드 호출 시")
+    class UpdateDomainTest {
+
+        @BeforeEach
+        void setUp() {
+            domainRepository = new StubDomainRepository();
+            linkRepository = new FakeLinkRepository();
+            domainService = new DomainService(domainRepository, linkRepository);
+        }
+
+        @Test
+        @DisplayName("성공: 도메인 정보가 없으면 새롭게 생성됨")
+        void createNewDomain() {
+            //given
+            Link link = LinkFixture.link();
+            linkRepository.stub(link);
+            UpdateDomainCommand command = new UpdateDomainCommand(link.getLinkId(), link.getUrl());
+
+            //when
+            UpdateDomainResponse response = domainService.updateDomain(command);
+
+            //then
+            assertThat(response.domainId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("성공: 도메인 정보가 있으면 기존 정보를 이용함")
+        void updateDomain() {
+            //given
+            Link link = LinkFixture.link();
+            Domain domain = DomainFixture.domain();
+            linkRepository.stub(link);
+            domainRepository.stub(domain);
+            UpdateDomainCommand command = new UpdateDomainCommand(link.getLinkId(), link.getUrl());
+
+            //when
+            UpdateDomainResponse response = domainService.updateDomain(command);
+
+            //then
+            assertThat(response.domainId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("예외(notFound): 존재하지 않는 링크")
+        void notFound_WhenLinkNotFound() {
+            //given
+            UpdateDomainCommand command = new UpdateDomainCommand(1L, "github.com");
+
+            //when
+            Exception exception = catchException(() -> domainService.updateDomain(command));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/domain/util/DomainExtractorTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/util/DomainExtractorTest.java
@@ -1,0 +1,53 @@
+package com.seong.shoutlink.domain.domain.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class DomainExtractorTest {
+
+    @Nested
+    @DisplayName("extractDomain 메서드 호출 시")
+    class ExtractRootDomainTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+            "https://github.com/hseong3243/shout-link, github.com",
+            "https://programmers.co.kr/, programmers.co.kr",
+            "www.google.com/search?q=skip-protocol, google.com",
+            "www.google.com/search?q=한글, google.com",
+            "github.com, github.com"
+        })
+        @DisplayName("성공: 루트 도메인 추출된다.")
+        void extractRootDomain(String url, String extractedDomain) {
+            //given
+            //when
+            String domain = DomainExtractor.extractRootDomain(url);
+
+            //then
+            assertThat(domain).isEqualTo(extractedDomain);
+        }
+
+        @Test
+        @DisplayName("예외(illegalArgument): url 형식이 아닐 때")
+        void ignore_WhenInputValueIsNotUrl() {
+            //given
+            String url = "asdf";
+
+            //when
+            Exception exception = catchException(() -> DomainExtractor.extractRootDomain(url));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ILLEGAL_ARGUMENT);
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/link/repository/FakeLinkRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/repository/FakeLinkRepository.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.link.repository;
 
+import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
 import com.seong.shoutlink.domain.link.service.LinkRepository;
@@ -8,6 +9,7 @@ import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class FakeLinkRepository implements LinkRepository {
 
@@ -41,5 +43,15 @@ public class FakeLinkRepository implements LinkRepository {
         int size) {
         List<Link> content = memory.values().stream().toList();
         return new LinkPaginationResult(content, content.size(), false);
+    }
+
+    @Override
+    public void updateLinkDomain(Link link, Domain domain) {
+
+    }
+
+    @Override
+    public Optional<Link> findById(Long linkId) {
+        return Optional.ofNullable(memory.get(linkId));
     }
 }

--- a/src/test/java/com/seong/shoutlink/fixture/DomainFixture/DomainFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/DomainFixture/DomainFixture.java
@@ -1,0 +1,17 @@
+package com.seong.shoutlink.fixture.DomainFixture;
+
+import com.seong.shoutlink.domain.domain.Domain;
+
+public class DomainFixture {
+
+    public static final long DOMAIN_ID = 1L;
+    public static final String ROOT_DOMAIN = "github.com";
+
+    public static Domain domain() {
+        return new Domain(DOMAIN_ID, ROOT_DOMAIN);
+    }
+
+    public static Domain domain(String url) {
+        return new Domain(DOMAIN_ID, url);
+    }
+}

--- a/src/test/java/com/seong/shoutlink/fixture/LinkFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/LinkFixture.java
@@ -5,7 +5,7 @@ import com.seong.shoutlink.domain.link.Link;
 public final class LinkFixture {
 
     public static final long LINK_ID = 1L;
-    public static final String URL = "url";
+    public static final String URL = "https://github.com/hseong3243";
     public static final String DESCRIPTION = "관심있는 곳";
 
     public static Link link() {

--- a/src/test/java/com/seong/shoutlink/global/event/DomainEventListenerTest.java
+++ b/src/test/java/com/seong/shoutlink/global/event/DomainEventListenerTest.java
@@ -1,0 +1,127 @@
+package com.seong.shoutlink.global.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.seong.shoutlink.base.BaseIntegrationTest;
+import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.domain.repository.DomainEntity;
+import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import com.seong.shoutlink.domain.link.repository.LinkEntity;
+import com.seong.shoutlink.domain.link.service.LinkService;
+import com.seong.shoutlink.domain.link.service.request.CreateLinkCommand;
+import com.seong.shoutlink.domain.link.service.response.CreateLinkResponse;
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import com.seong.shoutlink.domain.linkbundle.MemberLinkBundle;
+import com.seong.shoutlink.domain.linkbundle.repository.LinkBundleEntity;
+import com.seong.shoutlink.domain.linkbundle.service.LinkBundleRepository;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.service.MemberRepository;
+import com.seong.shoutlink.fixture.DomainFixture.DomainFixture;
+import com.seong.shoutlink.fixture.LinkBundleFixture;
+import com.seong.shoutlink.fixture.MemberFixture;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+@RecordApplicationEvents
+class DomainEventListenerTest extends BaseIntegrationTest {
+
+    @Autowired
+    private LinkService linkService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private LinkBundleRepository linkBundleRepository;
+
+    @Autowired
+    private DomainRepository domainRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Nested
+    @DisplayName("createLinkEvent 수신 시")
+    class CreateLinkEventTest {
+
+        @Test
+        @DisplayName("성공: 도메인 정보가 없으면 생성 됨")
+        void createDomainInfo() {
+            //given
+            Member member = MemberFixture.member();
+            memberRepository.save(member);
+            LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+            MemberLinkBundle memberLinkBundle = new MemberLinkBundle(member, linkBundle);
+            linkBundleRepository.save(memberLinkBundle);
+            CreateLinkCommand command = new CreateLinkCommand(member.getMemberId(),
+                linkBundle.getLinkBundleId(),
+                "github.com/hseong3243", "내 깃허브");
+
+            List<LinkBundleEntity> a = em.createQuery(
+                    "select lb from LinkBundleEntity lb", LinkBundleEntity.class)
+                .getResultList();
+            System.out.println(a.size());
+
+            //when
+            linkService.createLink(command);
+
+            //then
+            List<DomainEntity> result = em.createQuery("select d from DomainEntity d",
+                    DomainEntity.class)
+                .getResultList();
+            assertThat(result).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("성공: 도메인 정보가 있으면 생성되지 않음")
+        void updateDomainInfo() {
+            //given
+            Member member = MemberFixture.member();
+            memberRepository.save(member);
+            LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+            MemberLinkBundle memberLinkBundle = new MemberLinkBundle(member, linkBundle);
+            linkBundleRepository.save(memberLinkBundle);
+            Domain domain = DomainFixture.domain();
+            domainRepository.save(domain);
+            CreateLinkCommand command = new CreateLinkCommand(member.getMemberId(),
+                linkBundle.getLinkBundleId(),
+                domain.getRootDomain(), "내 깃허브");
+
+            //when
+            linkService.createLink(command);
+
+            //then
+            List<DomainEntity> result = em.createQuery("select d from DomainEntity d",
+                    DomainEntity.class)
+                .getResultList();
+            assertThat(result).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("성공: 링크 도메인 식별자가 업데이트 됨")
+        void updateLinkDomainId() {
+            //given
+            Member member = MemberFixture.member();
+            memberRepository.save(member);
+            LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+            MemberLinkBundle memberLinkBundle = new MemberLinkBundle(member, linkBundle);
+            linkBundleRepository.save(memberLinkBundle);
+            Domain domain = DomainFixture.domain();
+            CreateLinkCommand command = new CreateLinkCommand(member.getMemberId(),
+                linkBundle.getLinkBundleId(),
+                "github.com/hseong3243", "내 깃허브");
+
+            //when
+            CreateLinkResponse response = linkService.createLink(command);
+
+            //then
+            LinkEntity linkEntity = em.find(LinkEntity.class, response.linkId());
+            assertThat(linkEntity.getDomainId()).isNotNull();
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,9 @@ jwt:
   secret: bAM5hBSuhrVhI6aVvNPk1r9rR3n8Ar4Atest
   refresh-expiry-seconds: 18000
   refresh-secret: cjOYckwZQhEqZOCZCCjCIG4W0HFPfSjMtest
+spring:
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION
## 작업 내용

- 도메인 정보 업데이트 로직을 구현하였습니다.
- 도메인 정보가 없으면 생성 있으면 조회한 도메인 정보를 이용합니다.
- 링크 생성 이벤트를 이용합니다.
