### PR TITLE
Feat: 사용자는 도메인 검색 자동 완성을 사용할 수 있다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -140,3 +140,15 @@ operation::hub-controller-test/find-hub[snippets='http-request,path-parameters']
 ==== response
 
 operation::hub-controller-test/find-hub[snippets='http-response']
+
+== 도메인
+
+=== 루트 도메인 목록 조회
+
+==== request
+
+operation::domain-controller-test/find-root-domains[snippets='http-request,query-parameters']
+
+==== response
+
+operation::domain-controller-test/find-root-domains[snippets='http-response,response-fields']

--- a/src/main/java/com/seong/shoutlink/domain/common/Trie.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/Trie.java
@@ -1,0 +1,93 @@
+package com.seong.shoutlink.domain.common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class Trie {
+
+    @Getter
+    static class Node {
+
+        private final char c;
+        private final Map<Character, Node> children = new HashMap<>();
+        private boolean isWord;
+
+        public Node(char c) {
+            this.c = c;
+        }
+
+        public void setWord(boolean word) {
+            isWord = word;
+        }
+
+        public boolean hasChildren(char c) {
+            return children.containsKey(c);
+        }
+
+        public boolean isWord() {
+            return isWord;
+        }
+
+        public void addSuggestions(String word, List<String> suggestions, int count) {
+            children.forEach((character, childNode) -> {
+                String suggestionsWord = word + character;
+                if (childNode.isWord()) {
+                    suggestions.add(suggestionsWord);
+                }
+                if (suggestions.size() >= count) {
+                    return;
+                }
+                childNode.addSuggestions(suggestionsWord, suggestions, count);
+            });
+        }
+    }
+
+    private static final int MAX_SUGGESTION = 100;
+    private static final int MAX_WORD_LENGTH = 35;
+    private static final int MAX_PREFIX_LENGTH = 30;
+    public static final int ZERO = 0;
+
+    private final Node root = new Node(' ');
+
+    public synchronized void insert(String word) {
+        if(word.length() > MAX_WORD_LENGTH) {
+            return;
+        }
+
+        Node currentNode = root;
+        for (char c : word.toCharArray()) {
+            Map<Character, Node> children = currentNode.getChildren();
+            currentNode = children.getOrDefault(c, new Node(c));
+            children.put(c, currentNode);
+        }
+        currentNode.setWord(true);
+    }
+
+    public List<String> search(String prefix, int count) {
+        if(prefix.length() > MAX_PREFIX_LENGTH) {
+            prefix = prefix.substring(ZERO, MAX_PREFIX_LENGTH);
+        }
+        Node currentNode = root;
+        for (char c : prefix.toCharArray()) {
+            if (!currentNode.hasChildren(c)) {
+                return List.of();
+            }
+            Map<Character, Node> children = currentNode.getChildren();
+            currentNode = children.get(c);
+        }
+        return findWords(prefix, currentNode, Math.min(MAX_SUGGESTION, count));
+    }
+
+    private List<String> findWords(String word, Node currentNode, int count) {
+        List<String> suggestions = new ArrayList<>();
+        if (currentNode.isWord()) {
+            suggestions.add(word);
+        }
+        currentNode.addSuggestions(word, suggestions, count);
+        return suggestions;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/controller/DomainController.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/controller/DomainController.java
@@ -1,0 +1,29 @@
+package com.seong.shoutlink.domain.domain.controller;
+
+import com.seong.shoutlink.domain.domain.controller.request.FindRootDomainsRequest;
+import com.seong.shoutlink.domain.domain.service.DomainService;
+import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
+import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/domains")
+public class DomainController {
+
+    private final DomainService domainService;
+
+    @GetMapping("/search")
+    public ResponseEntity<FindRootDomainsResponse> findRootDomains(
+        @ModelAttribute @Valid FindRootDomainsRequest request) {
+        FindRootDomainsResponse response = domainService.findRootDomains(
+            new FindRootDomainsCommand(request.keyword(), request.size()));
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/controller/request/FindRootDomainsRequest.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/controller/request/FindRootDomainsRequest.java
@@ -1,0 +1,17 @@
+package com.seong.shoutlink.domain.domain.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+
+public record FindRootDomainsRequest(
+    @NotNull(message = "검색어는 필수입니다.")
+    @Size(min = 1, message = "검색어는 1자 이상이어야 합니다.")
+    String keyword,
+    Integer size) {
+
+    public FindRootDomainsRequest(String keyword, Integer size) {
+        this.keyword = keyword;
+        this.size = Objects.isNull(size) ? 10 : size;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainCacheRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainCacheRepository.java
@@ -5,4 +5,6 @@ import java.util.List;
 public interface DomainCacheRepository {
 
     List<String> findRootDomains(String prefix, int count);
+
+    void insert(String rootDomain);
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainCacheRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainCacheRepository.java
@@ -1,0 +1,8 @@
+package com.seong.shoutlink.domain.domain.repository;
+
+import java.util.List;
+
+public interface DomainCacheRepository {
+
+    List<String> findRootDomains(String prefix, int count);
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainJpaRepository.java
@@ -1,9 +1,14 @@
 package com.seong.shoutlink.domain.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DomainJpaRepository extends JpaRepository<DomainEntity, Long> {
 
     Optional<DomainEntity> findByRootDomain(String rootDomain);
+
+    @Query("select d.rootDomain from DomainEntity d")
+    List<String> findRootDomains();
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainMemoryRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainMemoryRepository.java
@@ -13,4 +13,9 @@ public class DomainMemoryRepository implements DomainCacheRepository {
     public List<String> findRootDomains(String prefix, int count) {
         return trie.search(prefix, count);
     }
+
+    @Override
+    public void insert(String rootDomain) {
+        trie.insert(rootDomain);
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainMemoryRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainMemoryRepository.java
@@ -1,0 +1,16 @@
+package com.seong.shoutlink.domain.domain.repository;
+
+import com.seong.shoutlink.domain.common.Trie;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DomainMemoryRepository implements DomainCacheRepository {
+
+    private final Trie trie = new Trie();
+
+    @Override
+    public List<String> findRootDomains(String prefix, int count) {
+        return trie.search(prefix, count);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.seong.shoutlink.domain.domain.repository;
 
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -22,5 +23,10 @@ public class DomainRepositoryImpl implements DomainRepository {
     public Domain save(Domain domain) {
         return domainJpaRepository.save(DomainEntity.create(domain))
             .toDomain();
+    }
+
+    @Override
+    public List<String> findRootDomains(String keyword, int size) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -30,4 +30,10 @@ public class DomainRepositoryImpl implements DomainRepository {
     public List<String> findRootDomains(String keyword, int size) {
         return domainCacheRepository.findRootDomains(keyword, size);
     }
+
+    @Override
+    public void synchronizeRootDomains() {
+        domainJpaRepository.findRootDomains().forEach(domainCacheRepository::insert);
+
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class DomainRepositoryImpl implements DomainRepository {
 
     private final DomainJpaRepository domainJpaRepository;
+    private final DomainCacheRepository domainCacheRepository;
 
     @Override
     public Optional<Domain> findByRootDomain(String rootDomain) {
@@ -27,6 +28,6 @@ public class DomainRepositoryImpl implements DomainRepository {
 
     @Override
     public List<String> findRootDomains(String keyword, int size) {
-        return null;
+        return domainCacheRepository.findRootDomains(keyword, size);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
@@ -1,6 +1,7 @@
 package com.seong.shoutlink.domain.domain.service;
 
 import com.seong.shoutlink.domain.domain.Domain;
+import java.util.List;
 import java.util.Optional;
 
 public interface DomainRepository {
@@ -8,4 +9,6 @@ public interface DomainRepository {
     Optional<Domain> findByRootDomain(String rootDomain);
 
     Domain save(Domain domain);
+
+    List<String> findRootDomains(String keyword, int size);
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
@@ -11,4 +11,6 @@ public interface DomainRepository {
     Domain save(Domain domain);
 
     List<String> findRootDomains(String keyword, int size);
+
+    void synchronizeRootDomains();
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
@@ -1,13 +1,16 @@
 package com.seong.shoutlink.domain.domain.service;
 
 import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
+import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
 import com.seong.shoutlink.domain.domain.util.DomainExtractor;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.service.LinkRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,5 +36,11 @@ public class DomainService {
             .orElseThrow(() -> new ShoutLinkException("존재하지 않는 링크입니다.", ErrorCode.NOT_FOUND));
         linkRepository.updateLinkDomain(link, domain);
         return new UpdateDomainResponse(domain.getDomainId());
+    }
+
+    public FindRootDomainsResponse findRootDomains(FindRootDomainsCommand command) {
+        List<String> rootDomains = domainRepository.findRootDomains(command.keyword(),
+            command.size());
+        return FindRootDomainsResponse.from(rootDomains);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/request/FindRootDomainsCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/request/FindRootDomainsCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.domain.service.request;
+
+public record FindRootDomainsCommand(String keyword, int size) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindRootDomainsResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindRootDomainsResponse.java
@@ -1,0 +1,10 @@
+package com.seong.shoutlink.domain.domain.service.response;
+
+import java.util.List;
+
+public record FindRootDomainsResponse(List<String> rootDomains) {
+
+    public static FindRootDomainsResponse from(List<String> rootDomains) {
+        return new FindRootDomainsResponse(rootDomains);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/config/SchedulerConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/SchedulerConfig.java
@@ -1,0 +1,17 @@
+package com.seong.shoutlink.global.config;
+
+import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import com.seong.shoutlink.global.scheduler.DomainScheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+    @Bean
+    public DomainScheduler domainScheduler(DomainRepository domainRepository) {
+        return new DomainScheduler(domainRepository);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/scheduler/DomainScheduler.java
+++ b/src/main/java/com/seong/shoutlink/global/scheduler/DomainScheduler.java
@@ -1,0 +1,16 @@
+package com.seong.shoutlink.global.scheduler;
+
+import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@RequiredArgsConstructor
+public class DomainScheduler {
+
+    private final DomainRepository domainRepository;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void synchronizeRootDomains() {
+        domainRepository.synchronizeRootDomains();
+    }
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -479,6 +479,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_허브_조회">허브 조회</a></li>
 </ul>
 </li>
+<li><a href="#_도메인">도메인</a>
+<ul class="sectlevel2">
+<li><a href="#_루트_도메인_목록_조회">루트 도메인 목록 조회</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -709,7 +714,7 @@ Content-Length: 20
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/link-bundles HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQyLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQyLCJyb2xlIjoiUk9MRV9VU0VSIn0.02TJ22pSXSTrGOSFF5dPId_sN6IUrNczAUFJSzcAIFE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Content-Length: 57
 Host: localhost:8080
 
@@ -825,7 +830,7 @@ Content-Length: 24
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/link-bundles HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQyLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQyLCJyb2xlIjoiUk9MRV9VU0VSIn0.02TJ22pSXSTrGOSFF5dPId_sN6IUrNczAUFJSzcAIFE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -930,7 +935,7 @@ Content-Length: 203
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs/1/link-bundles HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQyLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQyLCJyb2xlIjoiUk9MRV9VU0VSIn0.02TJ22pSXSTrGOSFF5dPId_sN6IUrNczAUFJSzcAIFE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Content-Length: 53
 Host: localhost:8080
 
@@ -1068,7 +1073,7 @@ Content-Length: 24
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hubs/1/link-bundles HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQyLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQyLCJyb2xlIjoiUk9MRV9VU0VSIn0.02TJ22pSXSTrGOSFF5dPId_sN6IUrNczAUFJSzcAIFE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1196,7 +1201,7 @@ Content-Length: 109
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/links HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQyLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQyLCJyb2xlIjoiUk9MRV9VU0VSIn0.02TJ22pSXSTrGOSFF5dPId_sN6IUrNczAUFJSzcAIFE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Content-Length: 100
 Host: localhost:8080
 
@@ -1318,7 +1323,7 @@ Content-Length: 18
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/links?linkBundleId=1&amp;page=0&amp;size=10 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQyLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQyLCJyb2xlIjoiUk9MRV9VU0VSIn0.02TJ22pSXSTrGOSFF5dPId_sN6IUrNczAUFJSzcAIFE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1385,7 +1390,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs/1/links HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQxLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQxLCJyb2xlIjoiUk9MRV9VU0VSIn0.pAyb8fsrReSTc_5r3qBoVymRaxvkn9DSdqjy_puYFt8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Content-Length: 69
 Host: localhost:8080
 
@@ -1529,7 +1534,7 @@ Content-Length: 18
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hubs/1/links?linkBundleId=1&amp;page=0&amp;size=20 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQxLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQxLCJyb2xlIjoiUk9MRV9VU0VSIn0.pAyb8fsrReSTc_5r3qBoVymRaxvkn9DSdqjy_puYFt8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1698,7 +1703,7 @@ Content-Length: 135
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzA4NzAxMzQxLCJzdWIiOiIxIiwiZXhwIjoxNzA4NzA0OTQxLCJyb2xlIjoiUk9MRV9VU0VSIn0.pAyb8fsrReSTc_5r3qBoVymRaxvkn9DSdqjy_puYFt8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
 Content-Length: 88
 Host: localhost:8080
 
@@ -2003,11 +2008,100 @@ Content-Length: 162
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_도메인"><a class="link" href="#_도메인">도메인</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_루트_도메인_목록_조회"><a class="link" href="#_루트_도메인_목록_조회">루트 도메인 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_request_14"><a class="link" href="#_request_14">request</a></h4>
+<div class="sect4">
+<h5 id="_request_14_http_request"><a class="link" href="#_request_14_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/domains/search?keyword=searchKeyword&amp;size=20 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_request_14_query_parameters"><a class="link" href="#_request_14_query_parameters">Query parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>keyword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색어</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색어 목록 사이즈</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_13"><a class="link" href="#_response_13">response</a></h4>
+<div class="sect4">
+<h5 id="_response_13_http_response"><a class="link" href="#_response_13_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 38
+
+{
+  "rootDomains" : [ "github.com" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_13_response_fields"><a class="link" href="#_response_13_response_fields">Response fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>rootDomains</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">루트 도메인 목록</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-24 00:15:30 +0900
+Last updated 2024-03-27 18:30:27 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/seong/shoutlink/base/BaseControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/base/BaseControllerTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seong.shoutlink.base.BaseControllerTest.BaseControllerConfig;
 import com.seong.shoutlink.domain.auth.JwtProvider;
 import com.seong.shoutlink.domain.auth.service.AuthService;
+import com.seong.shoutlink.domain.domain.service.DomainService;
 import com.seong.shoutlink.domain.hub.service.HubService;
 import com.seong.shoutlink.domain.link.service.LinkService;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleService;
@@ -76,6 +77,9 @@ public class BaseControllerTest {
 
     @MockBean
     protected HubService hubService;
+
+    @MockBean
+    protected DomainService domainService;
 
     @BeforeEach
     void setUp(

--- a/src/test/java/com/seong/shoutlink/domain/common/TrieTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/common/TrieTest.java
@@ -1,0 +1,154 @@
+package com.seong.shoutlink.domain.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class TrieTest {
+
+    @Nested
+    @DisplayName("insert 호출 시")
+    class InsertTest {
+
+        @Test
+        @DisplayName("성공: 단어가 삽입된다.")
+        void insert() {
+            //given
+            Trie trie = new Trie();
+            String word = "hello";
+
+            //when
+            trie.insert(word);
+
+            //then
+            List<String> result = trie.search("hello", 20);
+            assertThat(result).hasSize(1);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "35, 1",
+            "36, 0"
+        })
+        @DisplayName("성공: 삽입할 수 있는 단어의 최대 길이는 35자이다.")
+        void insertableWordMaxLength_35(int wordLength, int resultSize) {
+            //given
+            Trie trie = new Trie();
+            String word = "a".repeat(wordLength);
+
+            //when
+            trie.insert(word);
+
+            //then
+            List<String> result = trie.search(word, 20);
+            assertThat(result).hasSize(resultSize);
+        }
+
+        @RepeatedTest(20)
+        @DisplayName("성공: 동시에 삽입되어도 손실되지 않는다.")
+        void concurrentInsert() throws InterruptedException {
+            //given
+            Trie trie = new Trie();
+            String prefix = "asdf";
+            int threadPoolSize = 26;
+            ExecutorService service = Executors.newFixedThreadPool(threadPoolSize);
+            CountDownLatch latch = new CountDownLatch(threadPoolSize);
+
+            //when
+            for (int i = 0; i < threadPoolSize; i++) {
+                int finalI = i;
+                service.submit(() -> {
+                    try {
+                        StringBuilder sb = new StringBuilder(prefix);
+                        sb.append((char) ('a' + finalI));
+                        trie.insert(sb.toString());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            //then
+            List<String> result = trie.search(prefix, 100);
+            assertThat(result).hasSize(threadPoolSize);
+        }
+    }
+
+    @Nested
+    @DisplayName("search 호출 시")
+    class SearchTest {
+
+        @Test
+        @DisplayName("성공: 검색어 목록을 반환한다.")
+        void returnWordList() {
+            //given
+            Trie trie = new Trie();
+            String wordA = "hello";
+            String wordB = "hell";
+            String wordC = "helllllllssssso";
+            trie.insert(wordA);
+            trie.insert(wordB);
+            trie.insert(wordC);
+
+            //when
+            List<String> result = trie.search("he", 30);
+
+            //then
+            assertThat(result).containsExactlyInAnyOrder(wordA, wordB, wordC);
+        }
+
+        @Test
+        @DisplayName("성공: 검색어 목록의 최대 길이는 100개이다.")
+        void maxWordListSize_100() {
+            //given
+            Trie trie = new Trie();
+            String prefix = "asdf";
+            StringBuilder sb = new StringBuilder(prefix);
+            for (int i = 0; i < 26; i++) {
+                sb.append((char) ('a' + i));
+                for (int j = 0; j < 5; j++) {
+                    sb.append((char) ('a' + j));
+                    trie.insert(sb.toString());
+                    sb.deleteCharAt(sb.length() - 1);
+                }
+                sb.deleteCharAt(sb.length() - 1);
+            }
+
+            //when
+            List<String> result = trie.search(prefix, 130);
+
+            //then
+            assertThat(result).hasSize(100);
+        }
+
+        @Test
+        @DisplayName("성공: 유효한 검색어의 길이는 최대 30자이다.")
+        void maxSearchPrefix_30() {
+            //given
+            Trie trie = new Trie();
+            String prefix = "a".repeat(30);
+            trie.insert(prefix + "a");
+            trie.insert(prefix + "b");
+            trie.insert(prefix + "c");
+            trie.insert(prefix + "d");
+            trie.insert(prefix + "e");
+            prefix += "abcde";
+
+            //when
+            List<String> result = trie.search(prefix, 20);
+
+            //then
+            assertThat(result).hasSize(5);
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/domain/controller/DomainControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/controller/DomainControllerTest.java
@@ -1,0 +1,51 @@
+package com.seong.shoutlink.domain.domain.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.seong.shoutlink.base.BaseControllerTest;
+import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+class DomainControllerTest extends BaseControllerTest {
+
+    @Test
+    @DisplayName("루트 도메인 자동 완성 API 호출 시")
+    void findRootDomains() throws Exception {
+        //given
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("keyword", "searchKeyword");
+        params.add("size", "20");
+        FindRootDomainsResponse response = new FindRootDomainsResponse(List.of("github.com"));
+
+        given(domainService.findRootDomains(any())).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/domains/search")
+            .params(params));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                queryParameters(
+                    parameterWithName("keyword").description("검색어"),
+                    parameterWithName("size").description("검색어 목록 사이즈")
+                ),
+                responseFields(
+                    fieldWithPath("rootDomains").type(ARRAY).description("루트 도메인 목록")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
@@ -40,4 +40,11 @@ public class StubDomainRepository implements DomainRepository {
     public List<String> findRootDomains(String keyword, int size) {
         return searchAutoComplete.search(keyword, size);
     }
+
+    @Override
+    public void synchronizeRootDomains() {
+        for (Domain domain : memory.values()) {
+            searchAutoComplete.insert(domain.getRootDomain());
+        }
+    }
 }

--- a/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
@@ -1,17 +1,21 @@
 package com.seong.shoutlink.domain.domain.repository;
 
+import com.seong.shoutlink.domain.common.Trie;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.DomainRepository;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class StubDomainRepository implements DomainRepository {
 
     private final Map<Long, Domain> memory = new HashMap<>();
+    private final Trie searchAutoComplete = new Trie();
 
     public void stub(Domain domain) {
         memory.put(nextId(), domain);
+        searchAutoComplete.insert(domain.getRootDomain());
     }
 
     @Override
@@ -30,5 +34,10 @@ public class StubDomainRepository implements DomainRepository {
 
     private Long nextId() {
         return (long) (memory.size() + 1);
+    }
+
+    @Override
+    public List<String> findRootDomains(String keyword, int size) {
+        return searchAutoComplete.search(keyword, size);
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.repository.StubDomainRepository;
+import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
+import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
@@ -80,6 +82,35 @@ class DomainServiceTest {
             assertThat(exception).isInstanceOf(ShoutLinkException.class)
                 .extracting(e -> ((ShoutLinkException) e).getErrorCode())
                 .isEqualTo(ErrorCode.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("findRootDomains 호출 시")
+    class FindRootDomainsTest {
+
+        @BeforeEach
+        void setUp() {
+            domainRepository = new StubDomainRepository();
+            linkRepository = new FakeLinkRepository();
+            domainService = new DomainService(domainRepository, linkRepository);
+        }
+
+        @Test
+        @DisplayName("성공: 루트 도메인 문자열 목록을 반환한다.")
+        void findRootDomains() {
+            //given
+            String keyword = "git";
+            FindRootDomainsCommand command = new FindRootDomainsCommand(keyword, 10);
+            String rootDomain = "github.com";
+            Domain domain = DomainFixture.domain(rootDomain);
+            domainRepository.stub(domain);
+
+            //when
+            FindRootDomainsResponse response = domainService.findRootDomains(command);
+
+            //then
+            assertThat(response.rootDomains()).containsExactly(rootDomain);
         }
     }
 }


### PR DESCRIPTION
## 작업한 내용

- 루트 도메인 목록 반환 로직을 구현하였습니다.
  - 검색어 자동 완성을 위한 트라이를 구현하였습니다.
    - 최대 35자까지 삽입가능합니다.
    - 35자를 초과하는 경우 무시됩니다.
    - 검색어는 최대 30자까지 검색가능합니다. 30자를 초과하는 경우 30자까지 잘라서 검색합니다.
  - 트라이를 이용하여 애플리케이션 단에서 루트 도메인 목록을 캐시합니다.
    - 스케줄러가 매 시간 정각에 데이터베이스에서 조회 후 캐시합니다.