### PR TITLE
Feat: 사용자는 도메인을 검색할 수 있다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -152,3 +152,13 @@ operation::domain-controller-test/find-root-domains[snippets='http-request,query
 ==== response
 
 operation::domain-controller-test/find-root-domains[snippets='http-response,response-fields']
+
+=== 도메인 목록 조회
+
+==== request
+
+operation::domain-controller-test/find-domains[snippets='http-request,query-parameters']
+
+==== response
+
+operation::domain-controller-test/find-domains[snippets='http-response,response-fields']

--- a/src/main/java/com/seong/shoutlink/domain/domain/controller/DomainController.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/controller/DomainController.java
@@ -1,8 +1,11 @@
 package com.seong.shoutlink.domain.domain.controller;
 
+import com.seong.shoutlink.domain.domain.controller.request.FindDomainsRequest;
 import com.seong.shoutlink.domain.domain.controller.request.FindRootDomainsRequest;
 import com.seong.shoutlink.domain.domain.service.DomainService;
+import com.seong.shoutlink.domain.domain.service.request.FindDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,14 @@ public class DomainController {
         @ModelAttribute @Valid FindRootDomainsRequest request) {
         FindRootDomainsResponse response = domainService.findRootDomains(
             new FindRootDomainsCommand(request.keyword(), request.size()));
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<FindDomainsResponse> findDomains(
+        @ModelAttribute @Valid FindDomainsRequest request) {
+        FindDomainsResponse response = domainService.findDomains(new FindDomainsCommand(
+            request.keyword(), request.page(), request.size()));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/controller/request/FindDomainsRequest.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/controller/request/FindDomainsRequest.java
@@ -1,0 +1,18 @@
+package com.seong.shoutlink.domain.domain.controller.request;
+
+import jakarta.validation.constraints.Min;
+import java.util.Objects;
+
+public record FindDomainsRequest(
+    String keyword,
+    @Min(value = 0, message = "페이지는 음수일 수 없습니다.")
+    Integer page,
+    @Min(value = 1, message = "사이즈는 1이상이어야 합니다.")
+    Integer size) {
+
+    public FindDomainsRequest(String keyword, Integer page, Integer size) {
+        this.keyword = Objects.isNull(keyword) ? "" : keyword;
+        this.page = page;
+        this.size = size;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainJpaRepository.java
@@ -2,8 +2,11 @@ package com.seong.shoutlink.domain.domain.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DomainJpaRepository extends JpaRepository<DomainEntity, Long> {
 
@@ -11,4 +14,9 @@ public interface DomainJpaRepository extends JpaRepository<DomainEntity, Long> {
 
     @Query("select d.rootDomain from DomainEntity d")
     List<String> findRootDomains();
+
+    @Query("select d from DomainEntity d"
+        + " where d.rootDomain like :keyword%"
+        + " order by d.createdAt desc")
+    Page<DomainEntity> findDomains(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.seong.shoutlink.domain.domain.repository;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.DomainRepository;
 import java.util.List;
+import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -34,6 +35,10 @@ public class DomainRepositoryImpl implements DomainRepository {
     @Override
     public void synchronizeRootDomains() {
         domainJpaRepository.findRootDomains().forEach(domainCacheRepository::insert);
+    }
 
+    @Override
+    public DomainPaginationResult findDomains(String keyword, int page, int size) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -6,6 +6,8 @@ import java.util.List;
 import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -39,6 +41,11 @@ public class DomainRepositoryImpl implements DomainRepository {
 
     @Override
     public DomainPaginationResult findDomains(String keyword, int page, int size) {
-        return null;
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<DomainEntity> domains = domainJpaRepository.findDomains(keyword, pageRequest);
+        return new DomainPaginationResult(
+            domains.map(DomainEntity::toDomain).toList(),
+            domains.getTotalElements(),
+            domains.hasNext());
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
@@ -2,6 +2,7 @@ package com.seong.shoutlink.domain.domain.service;
 
 import com.seong.shoutlink.domain.domain.Domain;
 import java.util.List;
+import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import java.util.Optional;
 
 public interface DomainRepository {
@@ -13,4 +14,6 @@ public interface DomainRepository {
     List<String> findRootDomains(String keyword, int size);
 
     void synchronizeRootDomains();
+
+    DomainPaginationResult findDomains(String keyword, int page, int size);
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
@@ -1,10 +1,13 @@
 package com.seong.shoutlink.domain.domain.service;
 
 import com.seong.shoutlink.domain.domain.Domain;
+import com.seong.shoutlink.domain.domain.service.request.FindDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
+import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import com.seong.shoutlink.domain.domain.util.DomainExtractor;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
@@ -42,5 +45,11 @@ public class DomainService {
         List<String> rootDomains = domainRepository.findRootDomains(command.keyword(),
             command.size());
         return FindRootDomainsResponse.from(rootDomains);
+    }
+    
+    public FindDomainsResponse findDomains(FindDomainsCommand command) {
+        DomainPaginationResult result = domainRepository.findDomains(command.keyword(),
+            command.page(), command.size());
+        return FindDomainsResponse.of(result.domains(), result.totalElements(), result.hasNext());
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
@@ -46,7 +46,7 @@ public class DomainService {
             command.size());
         return FindRootDomainsResponse.from(rootDomains);
     }
-    
+
     public FindDomainsResponse findDomains(FindDomainsCommand command) {
         DomainPaginationResult result = domainRepository.findDomains(command.keyword(),
             command.page(), command.size());

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/request/FindDomainsCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/request/FindDomainsCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.domain.service.request;
+
+public record FindDomainsCommand(String keyword, int page, int size) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainResponse.java
@@ -1,0 +1,10 @@
+package com.seong.shoutlink.domain.domain.service.response;
+
+import com.seong.shoutlink.domain.domain.Domain;
+
+public record FindDomainResponse(Long domainId, String rootDomain) {
+
+    public static FindDomainResponse from(Domain domain) {
+        return new FindDomainResponse(domain.getDomainId(), domain.getRootDomain());
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainsResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainsResponse.java
@@ -1,0 +1,18 @@
+package com.seong.shoutlink.domain.domain.service.response;
+
+import com.seong.shoutlink.domain.domain.Domain;
+import java.util.List;
+
+public record FindDomainsResponse(
+    List<FindDomainResponse> domains,
+    long totalElements,
+    boolean hasNext) {
+
+    public static FindDomainsResponse of(List<Domain> domains, long totalElements,
+        boolean hasNext) {
+        List<FindDomainResponse> content = domains.stream()
+            .map(FindDomainResponse::from)
+            .toList();
+        return new FindDomainsResponse(content, totalElements, hasNext);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/result/DomainPaginationResult.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/result/DomainPaginationResult.java
@@ -1,0 +1,8 @@
+package com.seong.shoutlink.domain.domain.service.result;
+
+import com.seong.shoutlink.domain.domain.Domain;
+import java.util.List;
+
+public record DomainPaginationResult(List<Domain> domains, long totalElements, boolean hasNext) {
+
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -482,6 +482,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_도메인">도메인</a>
 <ul class="sectlevel2">
 <li><a href="#_루트_도메인_목록_조회">루트 도메인 목록 조회</a></li>
+<li><a href="#_도메인_목록_조회">도메인 목록 조회</a></li>
 </ul>
 </li>
 </ul>
@@ -714,7 +715,7 @@ Content-Length: 20
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/link-bundles HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Content-Length: 57
 Host: localhost:8080
 
@@ -830,7 +831,7 @@ Content-Length: 24
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/link-bundles HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -935,7 +936,7 @@ Content-Length: 203
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs/1/link-bundles HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Content-Length: 53
 Host: localhost:8080
 
@@ -1073,7 +1074,7 @@ Content-Length: 24
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hubs/1/link-bundles HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1201,7 +1202,7 @@ Content-Length: 109
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/links HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Content-Length: 100
 Host: localhost:8080
 
@@ -1323,7 +1324,7 @@ Content-Length: 18
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/links?linkBundleId=1&amp;page=0&amp;size=10 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1390,7 +1391,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs/1/links HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Content-Length: 69
 Host: localhost:8080
 
@@ -1534,7 +1535,7 @@ Content-Length: 18
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hubs/1/links?linkBundleId=1&amp;page=0&amp;size=20 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1703,7 +1704,7 @@ Content-Length: 135
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTMxNzM2LCJzdWIiOiIxIiwiZXhwIjoxNzExNTM1MzM2LCJyb2xlIjoiUk9MRV9VU0VSIn0.tgCEJM4UvjZH9-NHngy3wbLvlBrS27777kJBEhKMuAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNTUxODYyLCJzdWIiOiIxIiwiZXhwIjoxNzExNTU1NDYyLCJyb2xlIjoiUk9MRV9VU0VSIn0.DgO22AoYNm1WTp-l320ZpIsKYNXrD8LjHYQE2htCB50
 Content-Length: 88
 Host: localhost:8080
 
@@ -2095,13 +2096,126 @@ Content-Length: 38
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_도메인_목록_조회"><a class="link" href="#_도메인_목록_조회">도메인 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_request_15"><a class="link" href="#_request_15">request</a></h4>
+<div class="sect4">
+<h5 id="_request_15_http_request"><a class="link" href="#_request_15_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/domains?keyword=searchKeyword&amp;page=0&amp;size=10 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_request_15_query_parameters"><a class="link" href="#_request_15_query_parameters">Query parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>keyword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색어</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사이즈</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_14"><a class="link" href="#_response_14">response</a></h4>
+<div class="sect4">
+<h5 id="_response_14_http_response"><a class="link" href="#_response_14_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 123
+
+{
+  "domains" : [ {
+    "domainId" : 1,
+    "rootDomain" : "github.com"
+  } ],
+  "totalElements" : 1,
+  "hasNext" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_14_response_fields"><a class="link" href="#_response_14_response_fields">Response fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>domains</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">도메인 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>domains[].domainId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">도메인 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>domains[].rootDomain</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">루트 도메인</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">총 요소 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 페이지 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-27 18:30:27 +0900
+Last updated 2024-03-28 00:05:26 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/seong/shoutlink/domain/domain/controller/DomainControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/controller/DomainControllerTest.java
@@ -4,6 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -11,6 +14,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.seong.shoutlink.base.BaseControllerTest;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainResponse;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +50,41 @@ class DomainControllerTest extends BaseControllerTest {
                 ),
                 responseFields(
                     fieldWithPath("rootDomains").type(ARRAY).description("루트 도메인 목록")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 도메인 목록 조회 API 호출 시")
+    void findDomains() throws Exception {
+        //given
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("keyword", "searchKeyword");
+        params.add("page", "0");
+        params.add("size", "10");
+        List<FindDomainResponse> domains = List.of(new FindDomainResponse(1L, "github.com"));
+        FindDomainsResponse response = new FindDomainsResponse(domains, 1, false);
+
+        given(domainService.findDomains(any())).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/domains")
+            .params(params));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                queryParameters(
+                    parameterWithName("keyword").description("검색어"),
+                    parameterWithName("page").description("페이지"),
+                    parameterWithName("size").description("사이즈")
+                ),
+                responseFields(
+                    fieldWithPath("domains").type(ARRAY).description("도메인 목록"),
+                    fieldWithPath("domains[].domainId").type(NUMBER).description("도메인 ID"),
+                    fieldWithPath("domains[].rootDomain").type(STRING).description("루트 도메인"),
+                    fieldWithPath("totalElements").type(NUMBER).description("총 요소 개수"),
+                    fieldWithPath("hasNext").type(BOOLEAN).description("다음 페이지 여부")
                 )
             ));
     }

--- a/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
@@ -3,6 +3,7 @@ package com.seong.shoutlink.domain.domain.repository;
 import com.seong.shoutlink.domain.common.Trie;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,18 @@ public class StubDomainRepository implements DomainRepository {
         Long domainId = nextId();
         memory.put(domainId, domain);
         return new Domain(domainId, domain.getRootDomain());
+    }
+
+    @Override
+    public DomainPaginationResult findDomains(String keyword, int page, int size) {
+        List<Domain> list = memory.values().stream().toList();
+        int totalElements = list.size();
+        boolean hasNext = false;
+        if(list.size() > size) {
+            list = list.subList(0, size);
+            hasNext = true;
+        }
+        return new DomainPaginationResult(list, totalElements, hasNext);
     }
 
     private Long nextId() {

--- a/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.repository.StubDomainRepository;
+import com.seong.shoutlink.domain.domain.service.request.FindDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
 import com.seong.shoutlink.domain.exception.ErrorCode;
@@ -111,6 +113,36 @@ class DomainServiceTest {
 
             //then
             assertThat(response.rootDomains()).containsExactly(rootDomain);
+        }
+    }
+
+    @Nested
+    @DisplayName("findDomains 호출 시")
+    class FindDomainsTest {
+
+        @BeforeEach
+        void setUp() {
+            domainRepository = new StubDomainRepository();
+            linkRepository = new FakeLinkRepository();
+            domainService = new DomainService(domainRepository, linkRepository);
+        }
+
+        @Test
+        @DisplayName("성공: 도메인 목록을 반환한다.")
+        void findDomains() {
+            //given
+            String keyword = "keyword";
+            int page = 0;
+            int size = 10;
+            FindDomainsCommand command = new FindDomainsCommand(keyword, page, size);
+            Domain domain = DomainFixture.domain();
+            domainRepository.stub(domain);
+
+            //when
+            FindDomainsResponse response = domainService.findDomains(command);
+
+            //then
+            assertThat(response.domains()).hasSize(1);
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 도메인 목록 조회 로직을 구현하였습니다.
- 루트 도메인을 검색어로 입력받는 경우 `like 검색어%` 조건으로 필터링을 수행합니다.
- 표현 계층 dto에서 검색어가 null 인 경우 기본값을 ""(공백)으로 설정하였습니다.

## 관련 이슈

- close #58 