### PR TITLE
Feat: 사용자는 도메인과 연관된 링크 목록을 조회할 수 있다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -172,3 +172,13 @@ operation::domain-controller-test/find-domain[snippets='http-request,path-parame
 ==== response
 
 operation::domain-controller-test/find-domain[snippets='http-response,response-fields']
+
+=== 도메인 링크 목록 조회
+
+==== request
+
+operation::domain-controller-test/find-domain-links[snippets='http-request,path-parameters,query-parameters']
+
+==== response
+
+operation::domain-controller-test/find-domain-links[snippets='http-response,response-fields']

--- a/src/main/java/com/seong/shoutlink/domain/domain/controller/DomainController.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/controller/DomainController.java
@@ -1,12 +1,15 @@
 package com.seong.shoutlink.domain.domain.controller;
 
+import com.seong.shoutlink.domain.domain.controller.request.FindDomainLinksRequest;
 import com.seong.shoutlink.domain.domain.controller.request.FindDomainsRequest;
 import com.seong.shoutlink.domain.domain.controller.request.FindRootDomainsRequest;
 import com.seong.shoutlink.domain.domain.service.DomainService;
 import com.seong.shoutlink.domain.domain.service.request.FindDomainCommand;
+import com.seong.shoutlink.domain.domain.service.request.FindDomainLinksCommand;
 import com.seong.shoutlink.domain.domain.service.request.FindDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.response.FindDomainDetailResponse;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainLinksResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import jakarta.validation.Valid;
@@ -46,6 +49,15 @@ public class DomainController {
         @PathVariable("domainId") Long domainId) {
         FindDomainDetailResponse response
             = domainService.findDomain(new FindDomainCommand(domainId));
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{domainId}/links")
+    public ResponseEntity<FindDomainLinksResponse> findDomainLinks(
+        @PathVariable("domainId") Long domainId,
+        @ModelAttribute @Valid FindDomainLinksRequest request) {
+        FindDomainLinksResponse response = domainService.findDomainLinks(
+            new FindDomainLinksCommand(domainId, request.page(), request.size()));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/controller/request/FindDomainLinksRequest.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/controller/request/FindDomainLinksRequest.java
@@ -1,0 +1,17 @@
+package com.seong.shoutlink.domain.domain.controller.request;
+
+import jakarta.validation.constraints.Min;
+import java.util.Objects;
+import org.hibernate.validator.constraints.Range;
+
+public record FindDomainLinksRequest(
+    @Min(value = 0, message = "페이지는 음수일 수 없습니다.")
+    Integer page,
+    @Range(min = 1, max = 100, message = "사이즈는 1 이상 100 이하여야 합니다.")
+    Integer size) {
+
+    public FindDomainLinksRequest(Integer page, Integer size) {
+        this.page = Objects.isNull(page) ? 0 : page;
+        this.size = Objects.isNull(size) ? 10 : size;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.seong.shoutlink.domain.domain.repository;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.DomainRepository;
 import com.seong.shoutlink.domain.domain.service.result.DomainLinkPaginationResult;
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkResult;
+import com.seong.shoutlink.domain.link.repository.LinkJpaRepository;
 import java.util.List;
 import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import java.util.Optional;
@@ -17,6 +19,7 @@ public class DomainRepositoryImpl implements DomainRepository {
 
     private final DomainJpaRepository domainJpaRepository;
     private final DomainCacheRepository domainCacheRepository;
+    private final LinkJpaRepository linkJpaRepository;
 
     @Override
     public Optional<Domain> findByRootDomain(String rootDomain) {
@@ -58,6 +61,12 @@ public class DomainRepositoryImpl implements DomainRepository {
 
     @Override
     public DomainLinkPaginationResult findDomainLinks(Domain domain, int page, int size) {
-        return null;
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<DomainLinkResult> domainLinks
+            = linkJpaRepository.findDomainLinks(domain.getDomainId(), pageRequest);
+        return new DomainLinkPaginationResult(
+            domainLinks.getContent(),
+            domainLinks.getTotalElements(),
+            domainLinks.hasNext());
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.seong.shoutlink.domain.domain.repository;
 
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkPaginationResult;
 import java.util.List;
 import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import java.util.Optional;
@@ -53,5 +54,10 @@ public class DomainRepositoryImpl implements DomainRepository {
     public Optional<Domain> findById(Long domainId) {
         return domainJpaRepository.findById(domainId)
             .map(DomainEntity::toDomain);
+    }
+
+    @Override
+    public DomainLinkPaginationResult findDomainLinks(Domain domain, int page, int size) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
@@ -1,8 +1,9 @@
 package com.seong.shoutlink.domain.domain.service;
 
 import com.seong.shoutlink.domain.domain.Domain;
-import java.util.List;
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkPaginationResult;
 import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
+import java.util.List;
 import java.util.Optional;
 
 public interface DomainRepository {
@@ -18,4 +19,6 @@ public interface DomainRepository {
     DomainPaginationResult findDomains(String keyword, int page, int size);
 
     Optional<Domain> findById(Long domainId);
+
+    DomainLinkPaginationResult findDomainLinks(Domain domain, int page, int size);
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainService.java
@@ -2,13 +2,16 @@ package com.seong.shoutlink.domain.domain.service;
 
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.request.FindDomainCommand;
+import com.seong.shoutlink.domain.domain.service.request.FindDomainLinksCommand;
 import com.seong.shoutlink.domain.domain.service.request.FindDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.FindRootDomainsCommand;
 import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
 import com.seong.shoutlink.domain.domain.service.response.FindDomainDetailResponse;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainLinksResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkPaginationResult;
 import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
 import com.seong.shoutlink.domain.domain.util.DomainExtractor;
 import com.seong.shoutlink.domain.exception.ErrorCode;
@@ -56,8 +59,19 @@ public class DomainService {
     }
 
     public FindDomainDetailResponse findDomain(FindDomainCommand command) {
-        Domain domain = domainRepository.findById(command.domainId())
-            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 도메인입니다.", ErrorCode.NOT_FOUND));
+        Domain domain = getDomain(command.domainId());
         return FindDomainDetailResponse.from(domain);
+    }
+
+    public FindDomainLinksResponse findDomainLinks(FindDomainLinksCommand command) {
+        Domain domain = getDomain(command.domainId());
+        DomainLinkPaginationResult result
+            = domainRepository.findDomainLinks(domain, command.page(), command.size());
+        return FindDomainLinksResponse.of(result.links(), result.totalElements(), result.hasNext());
+    }
+
+    private Domain getDomain(Long domainId) {
+        return domainRepository.findById(domainId)
+            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 도메인입니다.", ErrorCode.NOT_FOUND));
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/request/FindDomainLinksCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/request/FindDomainLinksCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.domain.service.request;
+
+public record FindDomainLinksCommand(Long domainId, int page, int size) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainLinkResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainLinkResponse.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.domain.service.response;
+
+public record FindDomainLinkResponse(Long linkId, String url, long aggregationCount) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainLinksResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/response/FindDomainLinksResponse.java
@@ -1,0 +1,24 @@
+package com.seong.shoutlink.domain.domain.service.response;
+
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkResult;
+import java.util.List;
+
+public record FindDomainLinksResponse(
+    List<FindDomainLinkResponse> links,
+    long totalElements,
+    boolean hasNext) {
+
+
+    public static FindDomainLinksResponse of(
+        List<DomainLinkResult> links,
+        long totalElements,
+        boolean hasNext) {
+        List<FindDomainLinkResponse> content = links.stream()
+            .map(link -> new FindDomainLinkResponse(
+                link.linkId(),
+                link.url(),
+                link.aggregationCount())
+            ).toList();
+        return new FindDomainLinksResponse(content, totalElements, hasNext);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/result/DomainLinkPaginationResult.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/result/DomainLinkPaginationResult.java
@@ -1,0 +1,11 @@
+package com.seong.shoutlink.domain.domain.service.result;
+
+import java.util.List;
+
+public record DomainLinkPaginationResult(
+    List<DomainLinkResult> links,
+    long totalElements,
+    boolean hasNext) {
+
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/result/DomainLinkResult.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/result/DomainLinkResult.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.domain.service.result;
+
+public record DomainLinkResult(Long linkId, String url, long aggregationCount) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
@@ -1,10 +1,20 @@
 package com.seong.shoutlink.domain.link.repository;
 
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LinkJpaRepository extends JpaRepository<LinkEntity, Long> {
 
     Page<LinkEntity> findAllByLinkBundleId(Long linkBundleId, Pageable pageable);
+
+    @Query("select new com.seong.shoutlink.domain.domain.service.result.DomainLinkResult(l.linkId, l.url, count(l.url))"
+        + " from LinkEntity l"
+        + " where l.domainId = :domainId"
+        + " group by l.url"
+        + " order by count(l.url) desc")
+    Page<DomainLinkResult> findDomainLinks(@Param("domainId") Long domainId, Pageable pageable);
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -484,6 +484,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_루트_도메인_목록_조회">루트 도메인 목록 조회</a></li>
 <li><a href="#_도메인_목록_조회">도메인 목록 조회</a></li>
 <li><a href="#_도메인_단건_조회">도메인 단건 조회</a></li>
+<li><a href="#_도메인_링크_목록_조회">도메인 링크 목록 조회</a></li>
 </ul>
 </li>
 </ul>
@@ -716,7 +717,7 @@ Content-Length: 20
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/link-bundles HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Content-Length: 57
 Host: localhost:8080
 
@@ -832,7 +833,7 @@ Content-Length: 24
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/link-bundles HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -937,7 +938,7 @@ Content-Length: 203
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs/1/link-bundles HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Content-Length: 53
 Host: localhost:8080
 
@@ -1075,7 +1076,7 @@ Content-Length: 24
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hubs/1/link-bundles HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1203,7 +1204,7 @@ Content-Length: 109
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/links HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Content-Length: 100
 Host: localhost:8080
 
@@ -1325,7 +1326,7 @@ Content-Length: 18
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/links?linkBundleId=1&amp;page=0&amp;size=10 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1392,7 +1393,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs/1/links HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Content-Length: 69
 Host: localhost:8080
 
@@ -1536,7 +1537,7 @@ Content-Length: 18
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hubs/1/links?linkBundleId=1&amp;page=0&amp;size=20 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1705,7 +1706,7 @@ Content-Length: 135
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/hubs HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjI2NDM5LCJzdWIiOiIxIiwiZXhwIjoxNzExNjMwMDM5LCJyb2xlIjoiUk9MRV9VU0VSIn0.RiQMc9pgMkFKxG0oZO6q6R_HjPrHZeRMjOTegxbDwAc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNzExNjMxOTM1LCJzdWIiOiIxIiwiZXhwIjoxNzExNjM1NTM1LCJyb2xlIjoiUk9MRV9VU0VSIn0.0V1ZcvM6a1HPSMSbXJ2jVNijQKWJnCNVJrWnQNXG788
 Content-Length: 88
 Host: localhost:8080
 
@@ -2297,13 +2298,150 @@ Content-Length: 51
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_도메인_링크_목록_조회"><a class="link" href="#_도메인_링크_목록_조회">도메인 링크 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_request_17"><a class="link" href="#_request_17">request</a></h4>
+<div class="sect4">
+<h5 id="_request_17_http_request"><a class="link" href="#_request_17_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/domains/1/links?page=0&amp;size=10 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_request_17_path_parameters"><a class="link" href="#_request_17_path_parameters">Path parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/domains/{domainId}/links</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>domainId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">도메인 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_request_17_query_parameters"><a class="link" href="#_request_17_query_parameters">Query parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사이즈</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_16"><a class="link" href="#_response_16">response</a></h4>
+<div class="sect4">
+<h5 id="_response_16_http_response"><a class="link" href="#_response_16_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 151
+
+{
+  "links" : [ {
+    "linkId" : 1,
+    "url" : "github.com/hseong3243",
+    "aggregationCount" : 1
+  } ],
+  "totalElements" : 1,
+  "hasNext" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_16_response_fields"><a class="link" href="#_response_16_response_fields">Response fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>links</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">링크 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>links[].linkId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">링크 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>links[].url</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">링크 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>links[].aggregationCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">링크 집계 카운트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">총 요소 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 페이지 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-28 20:48:15 +0900
+Last updated 2024-03-28 22:19:59 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/seong/shoutlink/domain/domain/controller/DomainControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/controller/DomainControllerTest.java
@@ -16,6 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.seong.shoutlink.base.BaseControllerTest;
 import com.seong.shoutlink.domain.domain.service.response.FindDomainDetailResponse;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainLinkResponse;
+import com.seong.shoutlink.domain.domain.service.response.FindDomainLinksResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindDomainResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindDomainsResponse;
 import com.seong.shoutlink.domain.domain.service.response.FindRootDomainsResponse;
@@ -110,6 +112,43 @@ class DomainControllerTest extends BaseControllerTest {
                 responseFields(
                     fieldWithPath("domainId").type(NUMBER).description("도메인 ID"),
                     fieldWithPath("rootDomain").type(STRING).description("루트 도메인")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 도메인 링크 목록 조회 api 호출 시")
+    void findDomainLinks() throws Exception {
+        //given
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("page", "0");
+        params.add("size", "10");
+
+        FindDomainLinkResponse content = new FindDomainLinkResponse(1L, "github.com/hseong3243", 1);
+        FindDomainLinksResponse response = new FindDomainLinksResponse(List.of(content), 1L, false);
+        given(domainService.findDomainLinks(any())).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/domains/{domainId}/links", 1L)
+            .params(params));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                pathParameters(
+                    parameterWithName("domainId").description("도메인 ID")
+                ),
+                queryParameters(
+                    parameterWithName("page").description("페이지"),
+                    parameterWithName("size").description("사이즈")
+                ),
+                responseFields(
+                    fieldWithPath("links").type(ARRAY).description("링크 목록"),
+                    fieldWithPath("links[].linkId").type(NUMBER).description("링크 ID"),
+                    fieldWithPath("links[].url").type(STRING).description("링크 url"),
+                    fieldWithPath("links[].aggregationCount").type(NUMBER).description("링크 집계 카운트"),
+                    fieldWithPath("totalElements").type(NUMBER).description("총 요소 개수"),
+                    fieldWithPath("hasNext").type(BOOLEAN).description("다음 페이지 여부")
                 )
             ));
     }

--- a/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
@@ -3,7 +3,10 @@ package com.seong.shoutlink.domain.domain.repository;
 import com.seong.shoutlink.domain.common.Trie;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkPaginationResult;
+import com.seong.shoutlink.domain.domain.service.result.DomainLinkResult;
 import com.seong.shoutlink.domain.domain.service.result.DomainPaginationResult;
+import com.seong.shoutlink.domain.link.Link;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,11 +15,17 @@ import java.util.Optional;
 public class StubDomainRepository implements DomainRepository {
 
     private final Map<Long, Domain> memory = new HashMap<>();
+    private final Map<Domain, List<Link>> domainLinks = new HashMap<>();
     private final Trie searchAutoComplete = new Trie();
 
     public void stub(Domain domain) {
         memory.put(nextId(), domain);
         searchAutoComplete.insert(domain.getRootDomain());
+    }
+
+    public void stub(Domain domain, Link... links) {
+        memory.put(nextId(), domain);
+        domainLinks.put(domain, List.of(links));
     }
 
     @Override
@@ -52,6 +61,15 @@ public class StubDomainRepository implements DomainRepository {
 
     private Long nextId() {
         return (long) (memory.size() + 1);
+    }
+
+    @Override
+    public DomainLinkPaginationResult findDomainLinks(Domain domain, int page, int size) {
+        List<Link> links = domainLinks.get(domain);
+        List<DomainLinkResult> content = links.stream()
+            .map(link -> new DomainLinkResult(link.getLinkId(), link.getUrl(), links.size()))
+            .toList();
+        return new DomainLinkPaginationResult(content, links.size(), links.size() > size);
     }
 
     @Override


### PR DESCRIPTION
## 작업 내용

- 도메인 링크 목록 조회 로직을 구현하였습니다.
- 포함되는 정보는 기본적인 링크 아이디, 링크 url, 중복 링크 집계 카운트입니다.

## 관련 이슈

- close #61 