### PR TITLE
Feat: 사용자는 허브 태그 자동 생성 기능을 이용할 수 있다. 

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/common/ApiClient.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/ApiClient.java
@@ -1,0 +1,13 @@
+package com.seong.shoutlink.domain.common;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ApiClient {
+
+    Map<String, Object> post(
+        String url,
+        Map<String, List<String>> uriVariables,
+        Map<String, List<String>> headers,
+        String requestBody);
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/LinkBundleAndLinks.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/LinkBundleAndLinks.java
@@ -1,0 +1,18 @@
+package com.seong.shoutlink.domain.link;
+
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class LinkBundleAndLinks {
+
+    private final LinkBundle linkBundle;
+    private final List<Link> links;
+
+    public LinkBundleAndLinks(LinkBundle linkBundle, List<Link> links) {
+        this.linkBundle = linkBundle;
+        this.links = links;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/AutoGenerativeClient.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/AutoGenerativeClient.java
@@ -1,0 +1,10 @@
+package com.seong.shoutlink.domain.tag.service;
+
+import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand;
+import com.seong.shoutlink.domain.tag.service.ai.GeneratedTag;
+import java.util.List;
+
+public interface AutoGenerativeClient {
+
+    List<GeneratedTag> generateTags(GenerateAutoTagCommand command);
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/ai/GenerateAutoTagCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/ai/GenerateAutoTagCommand.java
@@ -1,0 +1,35 @@
+package com.seong.shoutlink.domain.tag.service.ai;
+
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.link.LinkBundleAndLinks;
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import java.util.List;
+
+public record GenerateAutoTagCommand(List<AutoTagLinkBundle> linkBundles) {
+
+    public record AutoTagLinkBundle(String description, List<AutoTagLink> links) {
+
+        public static AutoTagLinkBundle from(LinkBundle linkBundle, List<AutoTagLink> autoTagLinks) {
+            return new AutoTagLinkBundle(linkBundle.getDescription(), autoTagLinks);
+        }
+    }
+
+    public record AutoTagLink(String url, String description) {
+
+        public static AutoTagLink from(Link link) {
+            return new AutoTagLink(link.getUrl(), link.getDescription());
+        }
+    }
+
+    public static GenerateAutoTagCommand create(List<LinkBundleAndLinks> linkBundlesAndLinks) {
+        List<AutoTagLinkBundle> content = linkBundlesAndLinks.stream()
+            .map(linkBundleAndLinks -> {
+                List<AutoTagLink> autoTagLinks = linkBundleAndLinks.getLinks().stream()
+                    .map(AutoTagLink::from)
+                    .toList();
+                return AutoTagLinkBundle.from(linkBundleAndLinks.getLinkBundle(), autoTagLinks);
+            })
+            .toList();
+        return new GenerateAutoTagCommand(content);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/ai/GeneratedTag.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/ai/GeneratedTag.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.tag.service.ai;
+
+public record GeneratedTag(String name) {
+
+}

--- a/src/main/java/com/seong/shoutlink/global/client/ai/AutoTagPrompt.java
+++ b/src/main/java/com/seong/shoutlink/global/client/ai/AutoTagPrompt.java
@@ -1,0 +1,28 @@
+package com.seong.shoutlink.global.client.ai;
+
+import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand;
+import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand.AutoTagLink;
+import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand.AutoTagLinkBundle;
+
+public record AutoTagPrompt(String request, GenerateAutoTagCommand command) {
+
+    public String toPromptString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("요청:").append(request).append("\n")
+            .append("요약 대상:");
+        sb.append("{");
+        for (AutoTagLinkBundle linkBundle : command.linkBundles()) {
+            sb.append("링크 묶음 설명:").append(linkBundle.description());
+            sb.append("[");
+            for (AutoTagLink link : linkBundle.links()) {
+                sb.append("{");
+                sb.append("링크 설명:").append(link.description()).append(",")
+                    .append("url:").append(link.url());
+                sb.append("}");
+            }
+            sb.append("]");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/client/ai/GeminiClient.java
+++ b/src/main/java/com/seong/shoutlink/global/client/ai/GeminiClient.java
@@ -1,0 +1,79 @@
+package com.seong.shoutlink.global.client.ai;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seong.shoutlink.domain.common.ApiClient;
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.tag.service.AutoGenerativeClient;
+import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand;
+import com.seong.shoutlink.domain.tag.service.ai.GeneratedTag;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GeminiClient implements AutoGenerativeClient {
+
+    private static final Map<String, List<String>> HEADERS = new HashMap<>();
+    private static final Map<String, List<String>> URI_VARIABLES = Map.of();
+    private static final String API_KEY_HEADER = "x-goog-api-key";
+    private static final String GENERATE_TAG_PROMPT =
+        """
+        주어진 링크 묶음 설명, 링크 설명, url을 통해 사용자의 관심사를 추론하세요.
+        추론한 관심사는 {0}개의 키워드로 요약해서 응답하세요.
+        각 키워드는 10자 이내여야 하며 둘 이상인 경우 ,로 구분하세요.
+        """;
+
+    static {
+        HEADERS.put("Content-Type", List.of("application/json"));
+    }
+
+    private final String url;
+    private final ObjectMapper objectMapper;
+    private final ApiClient apiClient;
+
+    public GeminiClient(String url, String apiKey, ObjectMapper objectMapper, ApiClient apiClient) {
+        this.url = url;
+        this.objectMapper = objectMapper;
+        this.apiClient = apiClient;
+        HEADERS.put(API_KEY_HEADER, List.of(apiKey));
+    }
+
+    @Override
+    public List<GeneratedTag> generateTags(GenerateAutoTagCommand command) {
+        String requestPrompt = MessageFormat.format(GENERATE_TAG_PROMPT, 1);
+        AutoTagPrompt autoTagPrompt = new AutoTagPrompt(requestPrompt, command);
+        GeminiRequest geminiRequest = GeminiRequest.create(autoTagPrompt.toPromptString());
+        String requestBody = "";
+        try {
+            requestBody = objectMapper.writeValueAsString(geminiRequest);
+        } catch (JsonProcessingException e) {
+            throw new ShoutLinkException("문자열 변환에 실패하였습니다.", ErrorCode.ILLEGAL_ARGUMENT);
+        }
+
+        log.info("[Gemini] 태그 자동 생성 요청");
+        Object rawCandidates = apiClient.post(url, URI_VARIABLES, HEADERS, requestBody)
+            .get("candidates");
+        List<GeminiResponse.Candidate> candidates
+            = objectMapper.convertValue(rawCandidates, new TypeReference<>() {
+        });
+
+        log.info("[Gemini] 자동 생성된 태그 변환 시작");
+        String[] splitTags = candidates.stream()
+            .findFirst()
+            .map(GeminiResponse.Candidate::getResponse)
+            .map(tags -> tags.trim().split(","))
+            .orElseThrow(() -> new ShoutLinkException("유효한 candidate가 포함되어 있지 않습니다.",
+                ErrorCode.ILLEGAL_ARGUMENT));
+
+        log.info("[Gemini] 자동 생성된 태그 변환 성공");
+        return Arrays.stream(splitTags)
+            .map(rawTag -> new GeneratedTag(rawTag.trim()))
+            .toList();
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/client/ai/GeminiRequest.java
+++ b/src/main/java/com/seong/shoutlink/global/client/ai/GeminiRequest.java
@@ -1,0 +1,20 @@
+package com.seong.shoutlink.global.client.ai;
+
+import java.util.List;
+
+public record GeminiRequest(List<Content> contents) {
+
+    record Content(List<Part> parts) {
+
+    }
+
+    record Part(String text) {
+
+    }
+
+    static GeminiRequest create(String text) {
+        Part part = new Part(text);
+        Content content = new Content(List.of(part));
+        return new GeminiRequest(List.of(content));
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/client/ai/GeminiResponse.java
+++ b/src/main/java/com/seong/shoutlink/global/client/ai/GeminiResponse.java
@@ -1,0 +1,29 @@
+package com.seong.shoutlink.global.client.ai;
+
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import java.util.List;
+
+public record GeminiResponse(List<Candidate> candidates) {
+
+    record Candidate(Content content) {
+
+        public String getResponse() {
+            return content.getResponse();
+        }
+    }
+
+    record Content(List<Part> parts, String role) {
+
+        public String getResponse() {
+            Part part = parts.stream()
+                .findFirst()
+                .orElseThrow(() -> new ShoutLinkException("", ErrorCode.ILLEGAL_ARGUMENT));
+            return part.text();
+        }
+    }
+
+    record Part(String text) {
+
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/client/api/RestApiClient.java
+++ b/src/main/java/com/seong/shoutlink/global/client/api/RestApiClient.java
@@ -1,0 +1,43 @@
+package com.seong.shoutlink.global.client.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seong.shoutlink.domain.common.ApiClient;
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+
+public class RestApiClient implements ApiClient {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public RestApiClient(ObjectMapper objectMapper) {
+        restClient = RestClient.create();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Map<String, Object> post(
+        String url,
+        Map<String, List<String>> uriVariables,
+        Map<String, List<String>> headers,
+        String requestBody) {
+        ResponseEntity<String> entity = restClient.post()
+            .uri(url, uriVariables)
+            .headers(httpHeaders -> httpHeaders.putAll(headers))
+            .body(requestBody)
+            .retrieve()
+            .toEntity(String.class);
+
+        try {
+            return objectMapper.readValue(entity.getBody(), new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new ShoutLinkException("API 응답을 읽는데 실패하였습니다.", ErrorCode.ILLEGAL_ARGUMENT);
+        }
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/config/AiConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/AiConfig.java
@@ -1,0 +1,22 @@
+package com.seong.shoutlink.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seong.shoutlink.domain.tag.service.AutoGenerativeClient;
+import com.seong.shoutlink.domain.common.ApiClient;
+import com.seong.shoutlink.global.client.ai.GeminiClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiConfig {
+
+    @Bean
+    public AutoGenerativeClient autoGenerativeClient(
+        @Value("${gemini.url}") String url,
+        @Value("${gemini.api-key}") String apiKey,
+        ObjectMapper objectMapper,
+        ApiClient apiClient) {
+        return new GeminiClient(url, apiKey, objectMapper, apiClient);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/config/ApiConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/ApiConfig.java
@@ -1,0 +1,16 @@
+package com.seong.shoutlink.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seong.shoutlink.domain.common.ApiClient;
+import com.seong.shoutlink.global.client.api.RestApiClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApiConfig {
+
+    @Bean
+    public ApiClient apiClient(ObjectMapper objectMapper) {
+        return new RestApiClient(objectMapper);
+    }
+}

--- a/src/test/java/com/seong/shoutlink/fixture/ApiFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/ApiFixture.java
@@ -1,0 +1,65 @@
+package com.seong.shoutlink.fixture;
+
+public final class ApiFixture {
+
+    public static int DEFAULT_FIXED_TAG_COUNT = 3;
+
+    public static String geminiResponse() {
+        return """
+                  {
+                  "candidates": [
+                    {
+                      "content": {
+                        "parts": [
+                          {
+                            "text": "태그1,태그2,태그3"
+                          }
+                        ],
+                        "role": "model"
+                      },
+                      "finishReason": "STOP",
+                      "index": 0,
+                      "safetyRatings": [
+                        {
+                          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                          "probability": "NEGLIGIBLE"
+                        },
+                        {
+                          "category": "HARM_CATEGORY_HATE_SPEECH",
+                          "probability": "NEGLIGIBLE"
+                        },
+                        {
+                          "category": "HARM_CATEGORY_HARASSMENT",
+                          "probability": "NEGLIGIBLE"
+                        },
+                        {
+                          "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                          "probability": "NEGLIGIBLE"
+                        }
+                      ]
+                    }
+                  ],
+                  "promptFeedback": {
+                    "safetyRatings": [
+                      {
+                        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                        "probability": "NEGLIGIBLE"
+                      },
+                      {
+                        "category": "HARM_CATEGORY_HATE_SPEECH",
+                        "probability": "NEGLIGIBLE"
+                      },
+                      {
+                        "category": "HARM_CATEGORY_HARASSMENT",
+                        "probability": "NEGLIGIBLE"
+                      },
+                      {
+                        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                        "probability": "NEGLIGIBLE"
+                      }
+                    ]
+                  }
+                }
+                                """;
+    }
+}

--- a/src/test/java/com/seong/shoutlink/global/client/GeminiClientTest.java
+++ b/src/test/java/com/seong/shoutlink/global/client/GeminiClientTest.java
@@ -1,0 +1,62 @@
+package com.seong.shoutlink.global.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand;
+import com.seong.shoutlink.domain.link.LinkBundleAndLinks;
+import com.seong.shoutlink.domain.tag.service.ai.GeneratedTag;
+import com.seong.shoutlink.fixture.ApiFixture;
+import com.seong.shoutlink.fixture.LinkBundleFixture;
+import com.seong.shoutlink.fixture.LinkFixture;
+import com.seong.shoutlink.global.client.ai.GeminiClient;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GeminiClientTest {
+
+    GeminiClient geminiClient;
+    ObjectMapper objectMapper;
+    StubApiClient apiClient;
+
+    @BeforeEach
+    void setUp() {
+        apiClient = new StubApiClient();
+        objectMapper = new ObjectMapper().configure(
+            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        geminiClient = new GeminiClient("url", "apiKey", objectMapper, apiClient);
+    }
+
+    @Nested
+    @DisplayName("generateTags 호출 시")
+    class GenerateTagsTest {
+
+        @Test
+        @DisplayName("성공")
+        void generateTags() {
+            //given
+            LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+            Link link = LinkFixture.link();
+            LinkBundleAndLinks linkBundleAndLinks = new LinkBundleAndLinks(linkBundle,
+                List.of(link));
+            GenerateAutoTagCommand command = GenerateAutoTagCommand.create(
+                List.of(linkBundleAndLinks));
+
+            apiClient.stub(ApiFixture.geminiResponse());
+
+            //when
+            List<GeneratedTag> generatedTags = geminiClient.generateTags(command);
+
+            //then
+            assertThat(generatedTags)
+                .map(GeneratedTag::name)
+                .containsExactly("태그1", "태그2", "태그3");
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/global/client/StubApiClient.java
+++ b/src/test/java/com/seong/shoutlink/global/client/StubApiClient.java
@@ -1,0 +1,29 @@
+package com.seong.shoutlink.global.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seong.shoutlink.domain.common.ApiClient;
+import java.util.List;
+import java.util.Map;
+
+public class StubApiClient implements ApiClient {
+
+    private String stubValue;
+
+    public void stub(String jsonString) {
+        stubValue = jsonString;
+    }
+
+    @Override
+    public Map<String, Object> post(String url, Map<String, List<String>> uriVariables,
+        Map<String, List<String>> headers, String requestBody) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(stubValue, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,11 @@ jwt:
   secret: bAM5hBSuhrVhI6aVvNPk1r9rR3n8Ar4Atest
   refresh-expiry-seconds: 18000
   refresh-secret: cjOYckwZQhEqZOCZCCjCIG4W0HFPfSjMtest
+
+gemini:
+  url: https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent
+  api-key: fakeAPIKey
+
 spring:
   jpa:
     properties:


### PR DESCRIPTION
## 작업 내용

- 구글 gemini api를 이용하여 태그 자동 생성 요청을 구현하였습니다.
  - 현재 gemini api를 무료로 사용할 수 있다는 점, open ai의 저렴한 모델인 gpt3.5에 비해서 높은 성능을 보인다는 점에서 gemini를 선택하였습니다.
- 통신에는 RestClient를 이용합니다.
- 태그 자동 생성을 사용하는 서비스 로직과 이를 트리거하는 이벤트는 별도의 이슈에서 작업합니다.