### PR TITLE
Feat: 허브 태그 자동 생성 로직을 구현한다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/exception/ErrorCode.java
+++ b/src/main/java/com/seong/shoutlink/domain/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     UNAUTHORIZED("SL301", Constants.FORBIDDEN),
     NOT_FOUND("SL401", Constants.NOT_FOUND),
     DUPLICATE_EMAIL("SL901", Constants.CONFLICT),
-    DUPLICATE_NICKNAME("SL902", Constants.BAD_REQUEST);
+    DUPLICATE_NICKNAME("SL902", Constants.BAD_REQUEST),
+    NOT_MET_CONDITION("SL1001", Constants.BAD_REQUEST);
 
     private final String errorCode;
     private final int status;

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
@@ -51,4 +51,8 @@ public class LinkEntity extends BaseEntity {
     public void updateDomainId(Domain domain) {
         domainId = domain.getDomainId();
     }
+
+    public boolean isContainsIn(LinkBundle linkBundle) {
+        return linkBundleId.equals(linkBundle.getLinkBundleId());
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
@@ -1,6 +1,7 @@
 package com.seong.shoutlink.domain.link.repository;
 
 import com.seong.shoutlink.domain.domain.service.result.DomainLinkResult;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,6 @@ public interface LinkJpaRepository extends JpaRepository<LinkEntity, Long> {
         + " group by l.url"
         + " order by count(l.url) desc")
     Page<DomainLinkResult> findDomainLinks(@Param("domainId") Long domainId, Pageable pageable);
+
+    List<LinkEntity> findAllByLinkBundleIdIn(List<Long> linkBundleIds);
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
@@ -57,6 +57,15 @@ public class LinkRepositoryImpl implements LinkRepository {
 
     @Override
     public List<LinkWithLinkBundle> findAllByLinkBundlesIn(List<LinkBundle> linkBundles) {
-        return null;
+        List<Long> linkBundleIds = linkBundles.stream()
+            .map(LinkBundle::getLinkBundleId)
+            .toList();
+        List<LinkEntity> linkEntities = linkJpaRepository.findAllByLinkBundleIdIn(linkBundleIds);
+        Map<Long, LinkBundle> linkBundleIdAndLinkBundle = linkBundles.stream()
+            .collect(Collectors.toMap(LinkBundle::getLinkBundleId, linkBundle -> linkBundle));
+        return linkEntities.stream()
+            .map(linkEntity -> new LinkWithLinkBundle(linkEntity.toDomain(),
+                linkBundleIdAndLinkBundle.get(linkEntity.getLinkBundleId())))
+            .toList();
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
@@ -7,7 +7,9 @@ import com.seong.shoutlink.domain.link.service.LinkRepository;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -51,5 +53,10 @@ public class LinkRepositoryImpl implements LinkRepository {
     public Optional<Link> findById(Long linkId) {
         return linkJpaRepository.findById(linkId)
             .map(LinkEntity::toDomain);
+    }
+
+    @Override
+    public List<LinkWithLinkBundle> findAllByLinkBundlesIn(List<LinkBundle> linkBundles) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
@@ -5,6 +5,7 @@ import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import java.util.List;
 import java.util.Optional;
 
 public interface LinkRepository {
@@ -16,4 +17,6 @@ public interface LinkRepository {
     void updateLinkDomain(Link link, Domain domain);
 
     Optional<Link> findById(Long linkId);
+
+    List<LinkWithLinkBundle> findAllByLinkBundlesIn(List<LinkBundle> linkBundles);
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/HubTag.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/HubTag.java
@@ -1,0 +1,16 @@
+package com.seong.shoutlink.domain.tag;
+
+import com.seong.shoutlink.domain.hub.Hub;
+import lombok.Getter;
+
+@Getter
+public class HubTag {
+
+    private final Hub hub;
+    private final Tag tag;
+
+    public HubTag(Hub hub, Tag tag) {
+        this.hub = hub;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/Tag.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/Tag.java
@@ -1,0 +1,19 @@
+package com.seong.shoutlink.domain.tag;
+
+import lombok.Getter;
+
+@Getter
+public class Tag {
+
+    private Long tagId;
+    private String name;
+
+    public Tag(String name) {
+        this(null, name);
+    }
+
+    public Tag(Long tagId, String name) {
+        this.tagId = tagId;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/HubTagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/HubTagEntity.java
@@ -1,0 +1,21 @@
+package com.seong.shoutlink.domain.tag.repository;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@DiscriminatorValue("hub")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubTagEntity extends TagEntity {
+
+    private Long hubId;
+
+    public HubTagEntity(String name, Long hubId) {
+        super(name);
+        this.hubId = hubId;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
@@ -1,0 +1,46 @@
+package com.seong.shoutlink.domain.tag.repository;
+
+import com.seong.shoutlink.domain.common.BaseEntity;
+import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.Tag;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "tag")
+@DiscriminatorColumn
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class TagEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tagId;
+
+    private String name;
+
+    protected TagEntity(String name) {
+        this.name = name;
+    }
+
+    public static TagEntity from(HubTag hubTag) {
+        Hub hub = hubTag.getHub();
+        Tag tag = hubTag.getTag();
+        return new HubTagEntity(tag.getName(), hub.getHubId());
+    }
+
+    public Tag toDomain() {
+        return new Tag(tagId, name);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
@@ -1,0 +1,7 @@
+package com.seong.shoutlink.domain.tag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagJpaRepository extends JpaRepository<TagEntity, Long> {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
@@ -1,7 +1,11 @@
 package com.seong.shoutlink.domain.tag.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TagJpaRepository extends JpaRepository<TagEntity, Long> {
 
+    @Query("delete from HubTagEntity t where t.hubId=:hubId")
+    long deleteByHubId(@Param("hubId") Long hubId);
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
@@ -11,16 +11,15 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class TagRepositoryImpl implements TagRepository {
 
-
+    private final TagJpaRepository tagJpaRepository;
 
     @Override
     public List<Tag> saveAll(List<HubTag> tags) {
-//        List<TagEntity> tagEntities = tags.stream()
-//            .map(TagEntity::from)
-//            .toList();
-//        return tagJpaRepository.saveAll(tagEntities).stream()
-//            .map(TagEntity::toDomain)
-//            .toList();
-        return null;
+        List<TagEntity> tagEntities = tags.stream()
+            .map(TagEntity::from)
+            .toList();
+        return tagJpaRepository.saveAll(tagEntities).stream()
+            .map(TagEntity::toDomain)
+            .toList();
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.seong.shoutlink.domain.tag.repository;
+
+import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.Tag;
+import com.seong.shoutlink.domain.tag.service.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TagRepositoryImpl implements TagRepository {
+
+
+
+    @Override
+    public List<Tag> saveAll(List<HubTag> tags) {
+//        List<TagEntity> tagEntities = tags.stream()
+//            .map(TagEntity::from)
+//            .toList();
+//        return tagJpaRepository.saveAll(tagEntities).stream()
+//            .map(TagEntity::toDomain)
+//            .toList();
+        return null;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.tag.repository;
 
+import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.tag.HubTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.service.TagRepository;
@@ -21,5 +22,10 @@ public class TagRepositoryImpl implements TagRepository {
         return tagJpaRepository.saveAll(tagEntities).stream()
             .map(TagEntity::toDomain)
             .toList();
+    }
+
+    @Override
+    public long deleteHubTags(Hub hub) {
+        return tagJpaRepository.deleteByHubId(hub.getHubId());
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
@@ -1,0 +1,10 @@
+package com.seong.shoutlink.domain.tag.service;
+
+import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.Tag;
+import java.util.List;
+
+public interface TagRepository {
+
+    List<Tag> saveAll(List<HubTag> tags);
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.tag.service;
 
+import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.tag.HubTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface TagRepository {
 
     List<Tag> saveAll(List<HubTag> tags);
+
+    long deleteHubTags(Hub hub);
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
@@ -46,12 +46,15 @@ public class TagService {
         GenerateAutoTagCommand generateAutoTagCommand = GenerateAutoTagCommand
             .create(linkBundlesAndLinks, generateTagCount);
 
-        List<HubTag> tags = autoGenerativeClient.generateTags(generateAutoTagCommand)
+        List<HubTag> hubTags = autoGenerativeClient.generateTags(generateAutoTagCommand)
             .stream()
             .map(generatedTag -> new Tag(generatedTag.name()))
             .map(tag -> new HubTag(hub, tag))
             .toList();
-        return CreateTagResponse.from(tagRepository.saveAll(tags));
+        if(!hubTags.isEmpty()) {
+            tagRepository.deleteHubTags(hub);
+        }
+        return CreateTagResponse.from(tagRepository.saveAll(hubTags));
     }
 
     private List<LinkBundleAndLinks> groupingLinks(List<LinkWithLinkBundle> links) {

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
@@ -1,0 +1,79 @@
+package com.seong.shoutlink.domain.tag.service;
+
+import static java.util.stream.Collectors.*;
+
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.hub.service.HubRepository;
+import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
+import com.seong.shoutlink.domain.link.service.LinkRepository;
+import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import com.seong.shoutlink.domain.linkbundle.service.LinkBundleRepository;
+import com.seong.shoutlink.domain.link.LinkBundleAndLinks;
+import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.Tag;
+import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateTagCommand;
+import com.seong.shoutlink.domain.tag.service.response.CreateTagResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+    private static final int MINIMUM_TAG_CONDITION = 5;
+    private static final int MAXIMUM_TAG_COUNT = 5;
+
+    private final TagRepository tagRepository;
+    private final HubRepository hubRepository;
+    private final LinkBundleRepository linkBundleRepository;
+    private final LinkRepository linkRepository;
+    private final AutoGenerativeClient autoGenerativeClient;
+
+    @Transactional
+    public CreateTagResponse autoCreateHubTags(AutoCreateTagCommand command) {
+        Hub hub = getHub(command.hubId());
+        List<LinkBundle> hubLinkBundles = linkBundleRepository.findHubLinkBundles(hub);
+        List<LinkWithLinkBundle> links = linkRepository.findAllByLinkBundlesIn(
+            hubLinkBundles);
+
+        List<LinkBundleAndLinks> linkBundlesAndLinks = groupingLinks(links);
+        int generateTagCount = calculateNumberOfTag(links);
+        GenerateAutoTagCommand generateAutoTagCommand = GenerateAutoTagCommand
+            .create(linkBundlesAndLinks, generateTagCount);
+
+        List<HubTag> tags = autoGenerativeClient.generateTags(generateAutoTagCommand)
+            .stream()
+            .map(generatedTag -> new Tag(generatedTag.name()))
+            .map(tag -> new HubTag(hub, tag))
+            .toList();
+        return CreateTagResponse.from(tagRepository.saveAll(tags));
+    }
+
+    private List<LinkBundleAndLinks> groupingLinks(List<LinkWithLinkBundle> links) {
+        return links.stream()
+            .collect(groupingBy(
+                LinkWithLinkBundle::getLinkBundle,
+                mapping(LinkWithLinkBundle::getLink, toList())))
+            .entrySet().stream()
+            .map(entry -> new LinkBundleAndLinks(entry.getKey(), entry.getValue()))
+            .toList();
+    }
+
+    private int calculateNumberOfTag(List<LinkWithLinkBundle> links) {
+        int totalLinkCount = links.size();
+        if (totalLinkCount < MINIMUM_TAG_CONDITION) {
+            throw new ShoutLinkException("태그 생성 조건을 충족하지 못했습니다.", ErrorCode.NOT_MET_CONDITION);
+        }
+        return Math.min(MAXIMUM_TAG_COUNT, totalLinkCount / MINIMUM_TAG_CONDITION);
+    }
+
+    private Hub getHub(Long hubId) {
+        return hubRepository.findById(hubId)
+            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 허브입니다.", ErrorCode.NOT_FOUND));
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/ai/GenerateAutoTagCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/ai/GenerateAutoTagCommand.java
@@ -5,7 +5,7 @@ import com.seong.shoutlink.domain.link.LinkBundleAndLinks;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import java.util.List;
 
-public record GenerateAutoTagCommand(List<AutoTagLinkBundle> linkBundles) {
+public record GenerateAutoTagCommand(List<AutoTagLinkBundle> linkBundles, int generateTagCount) {
 
     public record AutoTagLinkBundle(String description, List<AutoTagLink> links) {
 
@@ -21,7 +21,9 @@ public record GenerateAutoTagCommand(List<AutoTagLinkBundle> linkBundles) {
         }
     }
 
-    public static GenerateAutoTagCommand create(List<LinkBundleAndLinks> linkBundlesAndLinks) {
+    public static GenerateAutoTagCommand create(
+        List<LinkBundleAndLinks> linkBundlesAndLinks,
+        int generateTagCount) {
         List<AutoTagLinkBundle> content = linkBundlesAndLinks.stream()
             .map(linkBundleAndLinks -> {
                 List<AutoTagLink> autoTagLinks = linkBundleAndLinks.getLinks().stream()
@@ -30,6 +32,6 @@ public record GenerateAutoTagCommand(List<AutoTagLinkBundle> linkBundles) {
                 return AutoTagLinkBundle.from(linkBundleAndLinks.getLinkBundle(), autoTagLinks);
             })
             .toList();
-        return new GenerateAutoTagCommand(content);
+        return new GenerateAutoTagCommand(content, generateTagCount);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/request/AutoCreateTagCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/request/AutoCreateTagCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.tag.service.request;
+
+public record AutoCreateTagCommand(Long hubId) {
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/response/CreateTagResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/response/CreateTagResponse.java
@@ -1,0 +1,14 @@
+package com.seong.shoutlink.domain.tag.service.response;
+
+import com.seong.shoutlink.domain.tag.Tag;
+import java.util.List;
+
+public record CreateTagResponse(List<Long> tagIds) {
+
+    public static CreateTagResponse from(List<Tag> tags) {
+        List<Long> tagIds = tags.stream()
+            .map(Tag::getTagId)
+            .toList();
+        return new CreateTagResponse(tagIds);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/client/ai/GeminiClient.java
+++ b/src/main/java/com/seong/shoutlink/global/client/ai/GeminiClient.java
@@ -46,7 +46,8 @@ public class GeminiClient implements AutoGenerativeClient {
 
     @Override
     public List<GeneratedTag> generateTags(GenerateAutoTagCommand command) {
-        String requestPrompt = MessageFormat.format(GENERATE_TAG_PROMPT, 1);
+        String requestPrompt = MessageFormat.format(
+            GENERATE_TAG_PROMPT, command.generateTagCount());
         AutoTagPrompt autoTagPrompt = new AutoTagPrompt(requestPrompt, command);
         GeminiRequest geminiRequest = GeminiRequest.create(autoTagPrompt.toPromptString());
         String requestBody = "";

--- a/src/test/java/com/seong/shoutlink/domain/link/repository/FakeLinkRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/repository/FakeLinkRepository.java
@@ -6,6 +6,7 @@ import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
 import com.seong.shoutlink.domain.link.service.LinkRepository;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,5 +54,16 @@ public class FakeLinkRepository implements LinkRepository {
     @Override
     public Optional<Link> findById(Long linkId) {
         return Optional.ofNullable(memory.get(linkId));
+    }
+
+    @Override
+    public List<LinkWithLinkBundle> findAllByLinkBundlesIn(List<LinkBundle> linkBundles) {
+        List<LinkWithLinkBundle> result = new ArrayList<>();
+        List<Link> links = memory.values().stream().toList();
+        for(int i=0; i<links.size(); i++) {
+            LinkBundle linkBundle = linkBundles.get(i % linkBundles.size());
+            result.add(new LinkWithLinkBundle(links.get(i), linkBundle));
+        }
+        return result;
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
@@ -1,0 +1,34 @@
+package com.seong.shoutlink.domain.tag.repository;
+
+import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.Tag;
+import com.seong.shoutlink.domain.tag.service.TagRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class StubTagRepository implements TagRepository {
+
+    private final Map<Long, Tag> memory = new HashMap<>();
+
+    public void stub(Tag... tags) {
+        for (Tag tag : tags) {
+            memory.put(nextId(), tag);
+        }
+    }
+
+    private Long nextId() {
+        return (long) (memory.size() + 1);
+    }
+
+    @Override
+    public List<Tag> saveAll(List<HubTag> hubTags) {
+        for (HubTag hubTag : hubTags) {
+            memory.put(nextId(), hubTag.getTag());
+        }
+        return memory.entrySet().stream().map(entry -> {
+            Tag value = entry.getValue();
+            return new Tag(entry.getKey(), value.getName());
+        }).toList();
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.tag.repository;
 
+import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.tag.HubTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.service.TagRepository;
@@ -21,6 +22,10 @@ public class StubTagRepository implements TagRepository {
         return (long) (memory.size() + 1);
     }
 
+    public long count() {
+        return memory.size();
+    }
+
     @Override
     public List<Tag> saveAll(List<HubTag> hubTags) {
         for (HubTag hubTag : hubTags) {
@@ -30,5 +35,12 @@ public class StubTagRepository implements TagRepository {
             Tag value = entry.getValue();
             return new Tag(entry.getKey(), value.getName());
         }).toList();
+    }
+
+    @Override
+    public long deleteHubTags(Hub hub) {
+        int size = memory.size();
+        memory.clear();
+        return size;
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
@@ -19,6 +19,7 @@ import com.seong.shoutlink.fixture.LinkBundleFixture;
 import com.seong.shoutlink.fixture.LinkFixture;
 import com.seong.shoutlink.fixture.MemberFixture;
 import com.seong.shoutlink.fixture.StubHubRepository;
+import com.seong.shoutlink.fixture.TagFixture;
 import com.seong.shoutlink.global.client.StubApiClient;
 import com.seong.shoutlink.global.client.ai.GeminiClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +75,24 @@ class TagServiceTest {
 
             //then
             assertThat(response.tagIds()).hasSize(ApiFixture.DEFAULT_FIXED_TAG_COUNT);
+        }
+
+        @Test
+        @DisplayName("성공: 기존 태그는 삭제한다.")
+        void thenDeleteOldTags() {
+            //given
+            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+
+            hubRepository.stub(HubFixture.hub(MemberFixture.member()));
+            linkBundleRepository.stub(LinkBundleFixture.linkBundle());
+            linkRepository.stub(LinkFixture.links(5).toArray(Link[]::new));
+            tagRepository.stub(TagFixture.tag());
+
+            //when
+            tagService.autoCreateHubTags(command);
+
+            //then
+            assertThat(tagRepository.count()).isEqualTo(ApiFixture.DEFAULT_FIXED_TAG_COUNT);
         }
 
         @Test

--- a/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
@@ -1,0 +1,113 @@
+package com.seong.shoutlink.domain.tag.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.link.Link;
+import com.seong.shoutlink.domain.link.repository.FakeLinkRepository;
+import com.seong.shoutlink.domain.linkbundle.repository.FakeLinkBundleRepository;
+import com.seong.shoutlink.domain.tag.repository.StubTagRepository;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateTagCommand;
+import com.seong.shoutlink.domain.tag.service.response.CreateTagResponse;
+import com.seong.shoutlink.fixture.ApiFixture;
+import com.seong.shoutlink.fixture.HubFixture;
+import com.seong.shoutlink.fixture.LinkBundleFixture;
+import com.seong.shoutlink.fixture.LinkFixture;
+import com.seong.shoutlink.fixture.MemberFixture;
+import com.seong.shoutlink.fixture.StubHubRepository;
+import com.seong.shoutlink.global.client.StubApiClient;
+import com.seong.shoutlink.global.client.ai.GeminiClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TagServiceTest {
+
+    TagService tagService;
+    StubTagRepository tagRepository;
+    StubHubRepository hubRepository;
+    FakeLinkBundleRepository linkBundleRepository;
+    FakeLinkRepository linkRepository;
+    AutoGenerativeClient autoGenerativeClient;
+
+    @BeforeEach
+    void setUp() {
+        tagRepository = new StubTagRepository();
+        hubRepository = new StubHubRepository();
+        linkBundleRepository = new FakeLinkBundleRepository();
+        linkRepository = new FakeLinkRepository();
+        ObjectMapper objectMapper = new ObjectMapper().configure(
+            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        StubApiClient apiClient = new StubApiClient();
+        autoGenerativeClient = new GeminiClient("fakeUrl", "fakeApiKey", objectMapper, apiClient);
+
+        apiClient.stub(ApiFixture.geminiResponse());
+    }
+
+    @Nested
+    @DisplayName("autoCreateTag 호출 시")
+    class AutoCreateTagTest {
+
+        @BeforeEach
+        void setUp() {
+            tagService = new TagService(tagRepository, hubRepository, linkBundleRepository,
+                linkRepository, autoGenerativeClient);
+        }
+
+        @Test
+        @DisplayName("성공: 링크가 5개 이상인 경우 자동 태그 생성한다.")
+        void autoCreateTag() {
+            //given
+            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+
+            hubRepository.stub(HubFixture.hub(MemberFixture.member()));
+            linkBundleRepository.stub(LinkBundleFixture.linkBundle());
+            linkRepository.stub(LinkFixture.links(5).toArray(Link[]::new));
+
+            //when
+            CreateTagResponse response = tagService.autoCreateHubTags(command);
+
+            //then
+            assertThat(response.tagIds()).hasSize(ApiFixture.DEFAULT_FIXED_TAG_COUNT);
+        }
+
+        @Test
+        @DisplayName("예외(notMetCondition): 링크가 5개 미만인 경우")
+        void notMetCondition_WhenTotalLinkCountLT5() {
+            //given
+            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+
+            hubRepository.stub(HubFixture.hub(MemberFixture.member()));
+            linkBundleRepository.stub(LinkBundleFixture.linkBundle());
+            linkRepository.stub(LinkFixture.links(4).toArray(Link[]::new));
+
+            //when
+            Exception exception = catchException(() -> tagService.autoCreateHubTags(command));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+        }
+
+        @Test
+        @DisplayName("예외(notFound): 존재하지 않는 허브인 경우")
+        void notFound_WhenHubNotFound() {
+            //given
+            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+
+            //when
+            Exception exception = catchException(() -> tagService.autoCreateHubTags(command));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/fixture/LinkFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/LinkFixture.java
@@ -1,6 +1,8 @@
 package com.seong.shoutlink.fixture;
 
 import com.seong.shoutlink.domain.link.Link;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class LinkFixture {
 
@@ -10,5 +12,13 @@ public final class LinkFixture {
 
     public static Link link() {
         return new Link(LINK_ID, URL, DESCRIPTION);
+    }
+
+    public static List<Link> links(int count) {
+        List<Link> links = new ArrayList<>();
+        for(int i=1; i<=count; i++) {
+            links.add(new Link((long) i, URL, DESCRIPTION));
+        }
+        return links;
     }
 }

--- a/src/test/java/com/seong/shoutlink/fixture/TagFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/TagFixture.java
@@ -1,0 +1,10 @@
+package com.seong.shoutlink.fixture;
+
+import com.seong.shoutlink.domain.tag.Tag;
+
+public final class TagFixture {
+
+    public static Tag tag() {
+        return new Tag(1L, "태그1");
+    }
+}

--- a/src/test/java/com/seong/shoutlink/global/client/GeminiClientTest.java
+++ b/src/test/java/com/seong/shoutlink/global/client/GeminiClientTest.java
@@ -46,7 +46,7 @@ class GeminiClientTest {
             LinkBundleAndLinks linkBundleAndLinks = new LinkBundleAndLinks(linkBundle,
                 List.of(link));
             GenerateAutoTagCommand command = GenerateAutoTagCommand.create(
-                List.of(linkBundleAndLinks));
+                List.of(linkBundleAndLinks), 3);
 
             apiClient.stub(ApiFixture.geminiResponse());
 


### PR DESCRIPTION
## 작업 내용

- 허브 태그 자동 생성 서비스, 영속성 로직을 구현하였습니다.
- 링크 리포지토리에서 허브가 가진 링크 목록을 조회한 후 `자동 태그 생성` 요청을 보내기 위한 데이터로 가공합니다.
  - 영속성 로직은 최대한 간단한 데이터만 조회하도록 구성하였습니다.
- 링크 개수가 5개 미만인 경우 예외, 5개 이상인 경우 5로 나눈 몫만큼을 생성할 태그 개수로 합니다. 최대 태그 개수는 5개로 지정합니다.
- 새로운 태그가 만들어지는 경우 기존 태그는 제거합니다.
- `TagEntity`의 경우 추후 사용자 태그를 추가하는 경우를 고려하여 추상 클래스로 만들고 `HubTagEntity`가 이를 상속합니다.