### PR TITLE
Feat: 허브 태그 자동 생성 이벤트 리스너를 구현한다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
@@ -8,7 +8,8 @@ import com.seong.shoutlink.domain.hub.service.HubRepository;
 import com.seong.shoutlink.domain.hubmember.service.HubMemberRepository;
 import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
-import com.seong.shoutlink.domain.link.service.event.CreateLinkEvent;
+import com.seong.shoutlink.domain.link.service.event.CreateHubLinkEvent;
+import com.seong.shoutlink.domain.link.service.event.CreateMemberLinkEvent;
 import com.seong.shoutlink.domain.link.service.request.CreateHubLinkCommand;
 import com.seong.shoutlink.domain.link.service.request.CreateLinkCommand;
 import com.seong.shoutlink.domain.link.service.request.FindHubLinksCommand;
@@ -45,7 +46,8 @@ public class LinkService {
         Link link = new Link(command.url(), command.description());
         LinkWithLinkBundle linkWithLinkBundle = new LinkWithLinkBundle(link, linkBundle);
         Long linkId = linkRepository.save(linkWithLinkBundle);
-        eventPublisher.publishEvent(new CreateLinkEvent(linkId, command.url()));
+        eventPublisher.publishEvent(
+            new CreateMemberLinkEvent(linkId, link.getUrl(), member.getMemberId()));
         return new CreateLinkResponse(linkId);
     }
 
@@ -78,7 +80,7 @@ public class LinkService {
         LinkBundle hubLinkBundle = getHubLinkBundle(command.linkBundleId(), hub);
         Link link = new Link(command.url(), command.description());
         Long linkId = linkRepository.save(new LinkWithLinkBundle(link, hubLinkBundle));
-        eventPublisher.publishEvent(new CreateLinkEvent(linkId, command.url()));
+        eventPublisher.publishEvent(new CreateHubLinkEvent(linkId, link.getUrl(), hub.getHubId()));
         return new CreateHubLinkResponse(linkId);
     }
 

--- a/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateHubLinkEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateHubLinkEvent.java
@@ -1,0 +1,37 @@
+package com.seong.shoutlink.domain.link.service.event;
+
+import java.util.Objects;
+
+public class CreateHubLinkEvent extends CreateLinkEvent {
+
+    private final Long hubId;
+
+    public CreateHubLinkEvent(Long linkId, String url, Long hubId) {
+        super(linkId, url);
+        this.hubId = hubId;
+    }
+
+    public Long hubId() {
+        return hubId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        CreateHubLinkEvent that = (CreateHubLinkEvent) o;
+        return Objects.equals(hubId, that.hubId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), hubId);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateLinkEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateLinkEvent.java
@@ -2,6 +2,21 @@ package com.seong.shoutlink.domain.link.service.event;
 
 import com.seong.shoutlink.domain.common.Event;
 
-public record CreateLinkEvent(Long linkId, String url) implements Event {
+public abstract class CreateLinkEvent implements Event {
 
+    private final Long linkId;
+    private final String url;
+
+    protected CreateLinkEvent(Long linkId, String url) {
+        this.linkId = linkId;
+        this.url = url;
+    }
+
+    public Long linkId() {
+        return linkId;
+    }
+
+    public String url() {
+        return url;
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateMemberLinkEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/event/CreateMemberLinkEvent.java
@@ -1,0 +1,37 @@
+package com.seong.shoutlink.domain.link.service.event;
+
+import java.util.Objects;
+
+public class CreateMemberLinkEvent extends CreateLinkEvent{
+
+    private final Long memberId;
+
+    public CreateMemberLinkEvent(Long linkId, String url, Long memberId) {
+        super(linkId, url);
+        this.memberId = memberId;
+    }
+
+    public Long memberId() {
+        return memberId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        CreateMemberLinkEvent that = (CreateMemberLinkEvent) o;
+        return Objects.equals(memberId, that.memberId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), memberId);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
@@ -3,9 +3,11 @@ package com.seong.shoutlink.global.config;
 import com.seong.shoutlink.domain.common.EventPublisher;
 import com.seong.shoutlink.domain.domain.service.DomainService;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleService;
+import com.seong.shoutlink.domain.tag.service.TagService;
 import com.seong.shoutlink.global.event.DomainEventListener;
 import com.seong.shoutlink.global.event.LinkBundleEventListener;
 import com.seong.shoutlink.global.event.SpringEventPublisher;
+import com.seong.shoutlink.global.event.TagEventListener;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,12 +21,17 @@ public class EventConfig {
     }
 
     @Bean
-    public LinkBundleEventListener springEventListener(LinkBundleService linkBundleService) {
+    public LinkBundleEventListener linkBundleEventListener(LinkBundleService linkBundleService) {
         return new LinkBundleEventListener(linkBundleService);
     }
 
     @Bean
     public DomainEventListener domainEventListener(DomainService domainService) {
         return new DomainEventListener(domainService);
+    }
+
+    @Bean
+    public TagEventListener tagEventListener(TagService tagService) {
+        return new TagEventListener(tagService);
     }
 }

--- a/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
@@ -1,0 +1,35 @@
+package com.seong.shoutlink.global.event;
+
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.link.service.event.CreateHubLinkEvent;
+import com.seong.shoutlink.domain.tag.service.TagService;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateTagCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TagEventListener {
+
+    private final TagService tagService;
+
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createHubTags(CreateHubLinkEvent event) {
+        AutoCreateTagCommand command = new AutoCreateTagCommand(event.hubId());
+        try {
+            tagService.autoCreateHubTags(command);
+            log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족");
+        } catch (ShoutLinkException e) {
+            if(e.getErrorCode().equals(ErrorCode.NOT_MET_CONDITION)) {
+                log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족하지 않음");
+            } else {
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 허브 태그 자동 생성을 위한 이벤트 리스너를 추가하였습니다.
  - 해당 리스너는 `CreateHubLinkEvent`를 바라봅니다.
- 태그 생성 이벤트를 수정하였습니다.
  - 태그 생성을 위해 `hubId` 혹은 `memberId`가 필요하나 기존 이벤트에는 이것이 포함되어 있지 않았습니다. `linkId`를 이용해 `hubId`를 얻을 수는 있으나 조인이 여러번 필요하여 이벤트의 필드를 변경하는 것이 좀 더 괜찮을 것이라 판단하였습니다.
  - 기존 `CreateLinkEvent`를 추상 클래스로 변경하고 `CreateHubLinkEvent`, `CreateMemberLinkEvent`를 추가하였습니다.

## 관련 이슈

- close #67 