### PR TITLE
Fix: 허브 태그 자동 생성 조건을 수정한다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/tag/Tag.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/Tag.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.tag;
 
+import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
@@ -7,13 +8,22 @@ public class Tag {
 
     private Long tagId;
     private String name;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public Tag(String name) {
-        this(null, name);
+        this(null, name, null, null);
     }
 
-    public Tag(Long tagId, String name) {
+    public Tag(Long tagId, String name, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.tagId = tagId;
         this.name = name;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public boolean isCreatedWithinADay() {
+        LocalDateTime aDayAgo = LocalDateTime.now().minusDays(1);
+        return createdAt.isAfter(aDayAgo);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
@@ -41,6 +41,6 @@ public abstract class TagEntity extends BaseEntity {
     }
 
     public Tag toDomain() {
-        return new Tag(tagId, name);
+        return new Tag(tagId, name, getCreatedAt(), getUpdatedAt());
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.tag.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,4 +9,10 @@ public interface TagJpaRepository extends JpaRepository<TagEntity, Long> {
 
     @Query("delete from HubTagEntity t where t.hubId=:hubId")
     long deleteByHubId(@Param("hubId") Long hubId);
+
+    @Query("select t from HubTagEntity t"
+        + " where t.hubId=:hubId"
+        + " order by t.createdAt"
+        + " limit 1")
+    Optional<TagEntity> findLatestTagByHubId(Long hubId);
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.seong.shoutlink.domain.tag.HubTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.service.TagRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -27,5 +28,11 @@ public class TagRepositoryImpl implements TagRepository {
     @Override
     public long deleteHubTags(Hub hub) {
         return tagJpaRepository.deleteByHubId(hub.getHubId());
+    }
+
+    @Override
+    public Optional<Tag> findLatestTagByHub(Hub hub) {
+        return tagJpaRepository.findLatestTagByHubId(hub.getHubId())
+            .map(TagEntity::toDomain);
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
@@ -4,10 +4,13 @@ import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.tag.HubTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import java.util.List;
+import java.util.Optional;
 
 public interface TagRepository {
 
     List<Tag> saveAll(List<HubTag> tags);
 
     long deleteHubTags(Hub hub);
+
+    Optional<Tag> findLatestTagByHub(Hub hub);
 }

--- a/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
@@ -7,6 +7,7 @@ import com.seong.shoutlink.domain.tag.service.TagRepository;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class StubTagRepository implements TagRepository {
 
@@ -42,5 +43,10 @@ public class StubTagRepository implements TagRepository {
         int size = memory.size();
         memory.clear();
         return size;
+    }
+
+    @Override
+    public Optional<Tag> findLatestTagByHub(Hub hub) {
+        return memory.values().stream().findFirst();
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
@@ -33,7 +33,7 @@ public class StubTagRepository implements TagRepository {
         }
         return memory.entrySet().stream().map(entry -> {
             Tag value = entry.getValue();
-            return new Tag(entry.getKey(), value.getName());
+            return new Tag(entry.getKey(), value.getName(), value.getCreatedAt(), value.getUpdatedAt());
         }).toList();
     }
 

--- a/src/test/java/com/seong/shoutlink/fixture/TagFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/TagFixture.java
@@ -1,10 +1,15 @@
 package com.seong.shoutlink.fixture;
 
 import com.seong.shoutlink.domain.tag.Tag;
+import java.time.LocalDateTime;
 
 public final class TagFixture {
 
+    public static final long TAG_ID = 1L;
+    public static final String TAG_NAME = "태그1";
+    public static final LocalDateTime MORE_THEN_A_DAY = LocalDateTime.now().minusHours(25);
+
     public static Tag tag() {
-        return new Tag(1L, "태그1");
+        return new Tag(TAG_ID, TAG_NAME, MORE_THEN_A_DAY, MORE_THEN_A_DAY);
     }
 }


### PR DESCRIPTION
## 작업 내용

- 허브 태그 자동 생성 조건을 추가하였습니다.
  - 최근 하루 안에 만들어진 태그가 있는 경우 예외를 던집니다.
  - 링크 개수가 5의 배수가 아닌 경우 예외를 던집니다.

## 관련 이슈

- close #70 