### PR TITLE
Feat: 사용자 태그는 자동으로 생성된다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/tag/MemberTag.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/MemberTag.java
@@ -1,0 +1,16 @@
+package com.seong.shoutlink.domain.tag;
+
+import com.seong.shoutlink.domain.member.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberTag {
+
+    private final Member member;
+    private final Tag tag;
+
+    public MemberTag(Member member, Tag tag) {
+        this.member = member;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/MemberTagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/MemberTagEntity.java
@@ -1,0 +1,21 @@
+package com.seong.shoutlink.domain.tag.repository;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@DiscriminatorValue("member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTagEntity extends TagEntity {
+
+    private Long memberId;
+
+    public MemberTagEntity(String name, Long memberId) {
+        super(name);
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
@@ -2,7 +2,9 @@ package com.seong.shoutlink.domain.tag.repository;
 
 import com.seong.shoutlink.domain.common.BaseEntity;
 import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.MemberTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
@@ -38,6 +40,12 @@ public abstract class TagEntity extends BaseEntity {
         Hub hub = hubTag.getHub();
         Tag tag = hubTag.getTag();
         return new HubTagEntity(tag.getName(), hub.getHubId());
+    }
+
+    public static TagEntity from(MemberTag memberTag) {
+        Member member = memberTag.getMember();
+        Tag tag = memberTag.getTag();
+        return new MemberTagEntity(tag.getName(), member.getMemberId());
     }
 
     public Tag toDomain() {

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
@@ -22,4 +22,14 @@ public interface TagJpaRepository extends JpaRepository<TagEntity, Long> {
     @Query("select t from HubTagEntity t"
         + " where t.hubId in :hubIds")
     List<HubTagEntity> findTagsInHubIds(@Param("hubIds") List<Long> hubIds);
+
+    @Modifying
+    @Query("delete from MemberTagEntity t where t.memberId=:memberId")
+    void deleteByMemberId(Long memberId);
+
+    @Query("select t from MemberTagEntity t"
+        + " where t.memberId=:memberId"
+        + " order by t.createdAt"
+        + " limit 1")
+    Optional<TagEntity> findLatestTagByMemberId(Long memberId);
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
@@ -22,7 +22,7 @@ public class TagRepositoryImpl implements TagRepository, HubTagReader {
     private final TagJpaRepository tagJpaRepository;
 
     @Override
-    public List<Tag> saveAll(List<HubTag> tags) {
+    public List<Tag> saveHubTags(List<HubTag> tags) {
         List<TagEntity> tagEntities = tags.stream()
             .map(TagEntity::from)
             .toList();
@@ -44,17 +44,23 @@ public class TagRepositoryImpl implements TagRepository, HubTagReader {
 
     @Override
     public Optional<Tag> findLatestTagByMember(Member member) {
-        return Optional.empty();
+        return tagJpaRepository.findLatestTagByMemberId(member.getMemberId())
+            .map(TagEntity::toDomain);
     }
 
     @Override
     public void deleteMemberTags(Member member) {
-
+        tagJpaRepository.deleteByMemberId(member.getMemberId());
     }
 
     @Override
     public List<Tag> saveMemberTags(List<MemberTag> memberTags) {
-        return null;
+        List<TagEntity> tagEntities = memberTags.stream()
+            .map(TagEntity::from)
+            .toList();
+        return tagJpaRepository.saveAll(tagEntities).stream()
+            .map(TagEntity::toDomain)
+            .toList();
     }
 
     @Override

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
@@ -3,7 +3,9 @@ package com.seong.shoutlink.domain.tag.repository;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.hub.service.HubTagReader;
 import com.seong.shoutlink.domain.hub.service.result.HubTagResult;
+import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.MemberTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.service.TagRepository;
 import java.util.List;
@@ -38,6 +40,21 @@ public class TagRepositoryImpl implements TagRepository, HubTagReader {
     public Optional<Tag> findLatestTagByHub(Hub hub) {
         return tagJpaRepository.findLatestTagByHubId(hub.getHubId())
             .map(TagEntity::toDomain);
+    }
+
+    @Override
+    public Optional<Tag> findLatestTagByMember(Member member) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void deleteMemberTags(Member member) {
+
+    }
+
+    @Override
+    public List<Tag> saveMemberTags(List<MemberTag> memberTags) {
+        return null;
     }
 
     @Override

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
@@ -1,7 +1,9 @@
 package com.seong.shoutlink.domain.tag.service;
 
 import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.MemberTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,10 @@ public interface TagRepository {
     void deleteHubTags(Hub hub);
 
     Optional<Tag> findLatestTagByHub(Hub hub);
+
+    Optional<Tag> findLatestTagByMember(Member member);
+
+    void deleteMemberTags(Member member);
+
+    List<Tag> saveMemberTags(List<MemberTag> memberTags);
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface TagRepository {
 
-    List<Tag> saveAll(List<HubTag> tags);
+    List<Tag> saveHubTags(List<HubTag> tags);
 
     void deleteHubTags(Hub hub);
 

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
@@ -60,7 +60,7 @@ public class TagService {
         if (!hubTags.isEmpty()) {
             tagRepository.deleteHubTags(hub);
         }
-        return CreateTagResponse.from(tagRepository.saveAll(hubTags));
+        return CreateTagResponse.from(tagRepository.saveHubTags(hubTags));
     }
 
     private void checkHubTagIsCreatedWithinADay(Hub hub) {

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
@@ -11,10 +11,14 @@ import com.seong.shoutlink.domain.link.service.LinkRepository;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleRepository;
 import com.seong.shoutlink.domain.link.LinkBundleAndLinks;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.service.MemberRepository;
 import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.MemberTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.service.ai.GenerateAutoTagCommand;
-import com.seong.shoutlink.domain.tag.service.request.AutoCreateTagCommand;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateMemberTagCommand;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateHubTagCommand;
 import com.seong.shoutlink.domain.tag.service.response.CreateTagResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,15 +34,16 @@ public class TagService {
     private static final int ZERO = 0;
 
     private final TagRepository tagRepository;
+    private final MemberRepository memberRepository;
     private final HubRepository hubRepository;
     private final LinkBundleRepository linkBundleRepository;
     private final LinkRepository linkRepository;
     private final AutoGenerativeClient autoGenerativeClient;
 
     @Transactional
-    public CreateTagResponse autoCreateHubTags(AutoCreateTagCommand command) {
+    public CreateTagResponse autoCreateHubTags(AutoCreateHubTagCommand command) {
         Hub hub = getHub(command.hubId());
-        checkTagIsCreatedWithinADay(hub);
+        checkHubTagIsCreatedWithinADay(hub);
         List<LinkBundle> hubLinkBundles = linkBundleRepository.findHubLinkBundles(hub);
         List<LinkWithLinkBundle> links = linkRepository.findAllByLinkBundlesIn(hubLinkBundles);
 
@@ -58,11 +63,43 @@ public class TagService {
         return CreateTagResponse.from(tagRepository.saveAll(hubTags));
     }
 
-    private void checkTagIsCreatedWithinADay(Hub hub) {
+    private void checkHubTagIsCreatedWithinADay(Hub hub) {
         tagRepository.findLatestTagByHub(hub)
             .filter(Tag::isCreatedWithinADay)
             .ifPresent(tag -> {
                 throw new ShoutLinkException("태그 생성된 지 하루가 지나지 않았습니다.", ErrorCode.NOT_MET_CONDITION);});
+    }
+
+    @Transactional
+    public CreateTagResponse autoCreateMemberTags(AutoCreateMemberTagCommand command) {
+        Member member = getMember(command.memberId());
+        checkMemberTagIsCreatedWithinADay(member);
+        List<LinkBundle> linkBundles = linkBundleRepository.findLinkBundlesThatMembersHave(member);
+        List<LinkWithLinkBundle> links = linkRepository.findAllByLinkBundlesIn(linkBundles);
+
+        List<LinkBundleAndLinks> linkBundleAndLinks = groupingLinks(links);
+        int generateTagCount = calculateNumberOfTag(links);
+        GenerateAutoTagCommand generateAutoTagCommand = GenerateAutoTagCommand.create(
+            linkBundleAndLinks, generateTagCount);
+
+        List<MemberTag> memberTags = autoGenerativeClient.generateTags(generateAutoTagCommand)
+            .stream()
+            .map(generatedTag -> new Tag(generatedTag.name()))
+            .map(tag -> new MemberTag(member, tag))
+            .toList();
+        if(!memberTags.isEmpty()) {
+            tagRepository.deleteMemberTags(member);
+        }
+        return CreateTagResponse.from(tagRepository.saveMemberTags(memberTags));
+    }
+
+    private void checkMemberTagIsCreatedWithinADay(Member member) {
+        tagRepository.findLatestTagByMember(member)
+            .filter(Tag::isCreatedWithinADay)
+            .ifPresent(tag -> {
+                throw new ShoutLinkException("태그가 생성된 지 하루가 지나지 않았습니다.",
+                    ErrorCode.NOT_MET_CONDITION);
+            });
     }
 
     private List<LinkBundleAndLinks> groupingLinks(List<LinkWithLinkBundle> links) {
@@ -82,6 +119,11 @@ public class TagService {
             throw new ShoutLinkException("태그 생성 조건을 충족하지 못했습니다.", ErrorCode.NOT_MET_CONDITION);
         }
         return Math.min(MAXIMUM_TAG_COUNT, totalLinkCount / MINIMUM_TAG_CONDITION);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new ShoutLinkException("존재하지 않는 회원입니다.", ErrorCode.NOT_FOUND));
     }
 
     private Hub getHub(Long hubId) {

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/request/AutoCreateHubTagCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/request/AutoCreateHubTagCommand.java
@@ -1,5 +1,5 @@
 package com.seong.shoutlink.domain.tag.service.request;
 
-public record AutoCreateTagCommand(Long hubId) {
+public record AutoCreateHubTagCommand(Long hubId) {
 
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/request/AutoCreateMemberTagCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/request/AutoCreateMemberTagCommand.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.tag.service.request;
+
+public record AutoCreateMemberTagCommand(Long memberId) {
+
+}

--- a/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
@@ -4,7 +4,7 @@ import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.link.service.event.CreateHubLinkEvent;
 import com.seong.shoutlink.domain.tag.service.TagService;
-import com.seong.shoutlink.domain.tag.service.request.AutoCreateTagCommand;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateHubTagCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Propagation;
@@ -20,7 +20,7 @@ public class TagEventListener {
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createHubTags(CreateHubLinkEvent event) {
-        AutoCreateTagCommand command = new AutoCreateTagCommand(event.hubId());
+        AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(event.hubId());
         try {
             tagService.autoCreateHubTags(command);
             log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족");

--- a/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
@@ -3,8 +3,10 @@ package com.seong.shoutlink.global.event;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.link.service.event.CreateHubLinkEvent;
+import com.seong.shoutlink.domain.link.service.event.CreateMemberLinkEvent;
 import com.seong.shoutlink.domain.tag.service.TagService;
 import com.seong.shoutlink.domain.tag.service.request.AutoCreateHubTagCommand;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateMemberTagCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Propagation;
@@ -23,6 +25,22 @@ public class TagEventListener {
         AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(event.hubId());
         try {
             tagService.autoCreateHubTags(command);
+            log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족");
+        } catch (ShoutLinkException e) {
+            if(e.getErrorCode().equals(ErrorCode.NOT_MET_CONDITION)) {
+                log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족하지 않음");
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createMemberTags(CreateMemberLinkEvent event) {
+        AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(event.memberId());
+        try {
+            tagService.autoCreateMemberTags(command);
             log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족");
         } catch (ShoutLinkException e) {
             if(e.getErrorCode().equals(ErrorCode.NOT_MET_CONDITION)) {

--- a/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
@@ -1,7 +1,9 @@
 package com.seong.shoutlink.domain.tag.repository;
 
 import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.tag.HubTag;
+import com.seong.shoutlink.domain.tag.MemberTag;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.service.TagRepository;
 import java.util.HashMap;
@@ -32,10 +34,7 @@ public class StubTagRepository implements TagRepository {
         for (HubTag hubTag : hubTags) {
             memory.put(nextId(), hubTag.getTag());
         }
-        return memory.entrySet().stream().map(entry -> {
-            Tag value = entry.getValue();
-            return new Tag(entry.getKey(), value.getName(), value.getCreatedAt(), value.getUpdatedAt());
-        }).toList();
+        return memory.values().stream().toList();
     }
 
     @Override
@@ -46,5 +45,23 @@ public class StubTagRepository implements TagRepository {
     @Override
     public Optional<Tag> findLatestTagByHub(Hub hub) {
         return memory.values().stream().findFirst();
+    }
+
+    @Override
+    public Optional<Tag> findLatestTagByMember(Member member) {
+        return memory.values().stream().findFirst();
+    }
+
+    @Override
+    public void deleteMemberTags(Member member) {
+        memory.clear();
+    }
+
+    @Override
+    public List<Tag> saveMemberTags(List<MemberTag> memberTags) {
+        for (MemberTag memberTag : memberTags) {
+            memory.put(nextId(), memberTag.getTag());
+        }
+        return memory.values().stream().toList();
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/repository/StubTagRepository.java
@@ -30,7 +30,7 @@ public class StubTagRepository implements TagRepository {
     }
 
     @Override
-    public List<Tag> saveAll(List<HubTag> hubTags) {
+    public List<Tag> saveHubTags(List<HubTag> hubTags) {
         for (HubTag hubTag : hubTags) {
             memory.put(nextId(), hubTag.getTag());
         }

--- a/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
@@ -7,19 +7,21 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.hub.repository.StubHubRepository;
 import com.seong.shoutlink.domain.link.Link;
 import com.seong.shoutlink.domain.link.repository.FakeLinkRepository;
 import com.seong.shoutlink.domain.linkbundle.repository.FakeLinkBundleRepository;
+import com.seong.shoutlink.domain.member.repository.StubMemberRepository;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.repository.StubTagRepository;
-import com.seong.shoutlink.domain.tag.service.request.AutoCreateTagCommand;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateMemberTagCommand;
+import com.seong.shoutlink.domain.tag.service.request.AutoCreateHubTagCommand;
 import com.seong.shoutlink.domain.tag.service.response.CreateTagResponse;
 import com.seong.shoutlink.fixture.ApiFixture;
 import com.seong.shoutlink.fixture.HubFixture;
 import com.seong.shoutlink.fixture.LinkBundleFixture;
 import com.seong.shoutlink.fixture.LinkFixture;
 import com.seong.shoutlink.fixture.MemberFixture;
-import com.seong.shoutlink.domain.hub.repository.StubHubRepository;
 import com.seong.shoutlink.fixture.TagFixture;
 import com.seong.shoutlink.global.client.StubApiClient;
 import com.seong.shoutlink.global.client.ai.GeminiClient;
@@ -36,6 +38,7 @@ class TagServiceTest {
     TagService tagService;
     StubTagRepository tagRepository;
     StubHubRepository hubRepository;
+    StubMemberRepository memberRepository;
     FakeLinkBundleRepository linkBundleRepository;
     FakeLinkRepository linkRepository;
     AutoGenerativeClient autoGenerativeClient;
@@ -44,6 +47,7 @@ class TagServiceTest {
     void setUp() {
         tagRepository = new StubTagRepository();
         hubRepository = new StubHubRepository();
+        memberRepository = new StubMemberRepository();
         linkBundleRepository = new FakeLinkBundleRepository();
         linkRepository = new FakeLinkRepository();
         ObjectMapper objectMapper = new ObjectMapper().configure(
@@ -55,13 +59,13 @@ class TagServiceTest {
     }
 
     @Nested
-    @DisplayName("autoCreateTag 호출 시")
+    @DisplayName("autoCreateHubTag 호출 시")
     class AutoCreateTagTest {
 
         @BeforeEach
         void setUp() {
-            tagService = new TagService(tagRepository, hubRepository, linkBundleRepository,
-                linkRepository, autoGenerativeClient);
+            tagService = new TagService(tagRepository, memberRepository,
+                hubRepository, linkBundleRepository, linkRepository, autoGenerativeClient);
         }
 
         @ParameterizedTest
@@ -69,7 +73,7 @@ class TagServiceTest {
         @DisplayName("성공: 링크가 5의 배수인 경우 자동 태그 생성한다.")
         void autoCreateTag(int totalLinkSize) {
             //given
-            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+            AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(1L);
 
             hubRepository.stub(HubFixture.hub(MemberFixture.member()));
             linkBundleRepository.stub(LinkBundleFixture.linkBundle());
@@ -86,7 +90,7 @@ class TagServiceTest {
         @DisplayName("성공: 기존 태그는 삭제한다.")
         void thenDeleteOldTags() {
             //given
-            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+            AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(1L);
 
             hubRepository.stub(HubFixture.hub(MemberFixture.member()));
             linkBundleRepository.stub(LinkBundleFixture.linkBundle());
@@ -104,7 +108,7 @@ class TagServiceTest {
         @DisplayName("예외(notFound): 존재하지 않는 허브인 경우")
         void notFound_WhenHubNotFound() {
             //given
-            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+            AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(1L);
 
             //when
             Exception exception = catchException(() -> tagService.autoCreateHubTags(command));
@@ -119,7 +123,7 @@ class TagServiceTest {
         @DisplayName("예외(notMetCondition): 하루 안에 생성된 태그가 존재하는 경우")
         void notMetCondition_WhenLatestTagCreatedWithinADay() {
             //given
-            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+            AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(1L);
             LocalDateTime createdWithinADay = LocalDateTime.now().minusHours(23);
             Tag tag = new Tag(1L, "태그", createdWithinADay, createdWithinADay);
 
@@ -136,11 +140,11 @@ class TagServiceTest {
         }
 
         @ParameterizedTest
-        @CsvSource({"0","1","2","3","4"})
+        @CsvSource({"0", "1", "2", "3", "4"})
         @DisplayName("예외(notMetCondition): 링크가 5개 미만인 경우")
         void notMetCondition_WhenTotalLinkCountLT5(int totalLinkSize) {
             //given
-            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+            AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(1L);
 
             hubRepository.stub(HubFixture.hub(MemberFixture.member()));
             linkBundleRepository.stub(LinkBundleFixture.linkBundle());
@@ -156,11 +160,11 @@ class TagServiceTest {
         }
 
         @ParameterizedTest
-        @CsvSource({"6","9","11","14","16","19","21","24"})
+        @CsvSource({"6", "9", "11", "14", "16", "19", "21", "24"})
         @DisplayName("예외(notMetCondition): 링크 개수가 5의 배수가 아닐 때")
         void notMetCondition_WhenTotalLinkCountIsNotMultiplesOf5(int totalLinkSize) {
             //given
-            AutoCreateTagCommand command = new AutoCreateTagCommand(1L);
+            AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(1L);
 
             hubRepository.stub(HubFixture.hub(MemberFixture.member()));
             linkBundleRepository.stub(LinkBundleFixture.linkBundle());
@@ -168,6 +172,128 @@ class TagServiceTest {
 
             //when
             Exception exception = catchException(() -> tagService.autoCreateHubTags(command));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+        }
+    }
+
+    @Nested
+    @DisplayName("autoCreateMemberTags 호출 시")
+    class AutoCreateMemberTagsTest {
+
+        @BeforeEach
+        void setUp() {
+            tagService = new TagService(tagRepository, memberRepository,
+                hubRepository, linkBundleRepository, linkRepository, autoGenerativeClient);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"5", "10", "15", "20", "25"})
+        @DisplayName("성공: 링크가 5의 배수인 경우 자동 태그 생성한다.")
+        void autoCreateMemberTags(int totalLinkSize) {
+            //given
+            AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(1L);
+
+            memberRepository.stub(MemberFixture.member());
+            linkBundleRepository.stub(LinkBundleFixture.linkBundle());
+            linkRepository.stub(LinkFixture.links(totalLinkSize).toArray(Link[]::new));
+
+            //when
+            CreateTagResponse response = tagService.autoCreateMemberTags(command);
+
+            //then
+            assertThat(response.tagIds()).hasSize(ApiFixture.DEFAULT_FIXED_TAG_COUNT);
+        }
+
+        @Test
+        @DisplayName("성공: 기존 태그는 삭제한다.")
+        void thenDeleteOldTags() {
+            //given
+            AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(1L);
+
+            memberRepository.stub(MemberFixture.member());
+            linkBundleRepository.stub(LinkBundleFixture.linkBundle());
+            linkRepository.stub(LinkFixture.links(5).toArray(Link[]::new));
+            tagRepository.stub(TagFixture.tag());
+
+            //when
+            tagService.autoCreateMemberTags(command);
+
+            //then
+            assertThat(tagRepository.count()).isEqualTo(ApiFixture.DEFAULT_FIXED_TAG_COUNT);
+        }
+
+        @Test
+        @DisplayName("예외(notFound): 존재하지 않는 회원인 경우")
+        void notFound_WhenMemberNotFound() {
+            //given
+            AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(1L);
+
+            //when
+            Exception exception = catchException(() -> tagService.autoCreateMemberTags(command));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("예외(notMetCondition): 하루 안에 생성된 태그가 존재하는 경우")
+        void notMetCondition_WhenLatestTagCreatedWithinADay() {
+            //given
+            AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(1L);
+            LocalDateTime createdWithinADay = LocalDateTime.now().minusHours(23);
+            Tag tag = new Tag(1L, "태그", createdWithinADay, createdWithinADay);
+
+            memberRepository.stub(MemberFixture.member());
+            tagRepository.stub(tag);
+
+            //when
+            Exception exception = catchException(() -> tagService.autoCreateMemberTags(command));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"0", "1", "2", "3", "4"})
+        @DisplayName("예외(notMetCondition): 링크가 5개 미만인 경우")
+        void notMetCondition_WhenTotalLinkCountLT5(int totalLinkSize) {
+            //given
+            AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(1L);
+
+            memberRepository.stub(MemberFixture.member());
+            linkBundleRepository.stub(LinkBundleFixture.linkBundle());
+            linkRepository.stub(LinkFixture.links(totalLinkSize).toArray(Link[]::new));
+
+            //when
+            Exception exception = catchException(() -> tagService.autoCreateMemberTags(command));
+
+            //then
+            assertThat(exception).isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"6", "9", "11", "14", "16", "19", "21", "24"})
+        @DisplayName("예외(notMetCondition): 링크 개수가 5의 배수가 아닐 때")
+        void notMetCondition_WhenTotalLinkCountIsNotMultiplesOf5(int totalLinkSize) {
+            //given
+            AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(1L);
+
+            memberRepository.stub(MemberFixture.member());
+            linkBundleRepository.stub(LinkBundleFixture.linkBundle());
+            linkRepository.stub(LinkFixture.links(totalLinkSize).toArray(Link[]::new));
+
+            //when
+            Exception exception = catchException(() -> tagService.autoCreateMemberTags(command));
 
             //then
             assertThat(exception).isInstanceOf(ShoutLinkException.class)


### PR DESCRIPTION
## 작업 내용

- 회원 태그 자동 생성 로직을 구현하였습니다.
- 기존에 구현하였던 허브 태그 자동 생성 기능과 유사한 맥락을 가집니다.
- 동일하게 제미니 api 클라이언트를 사용합니다.