### PR TITLE
Refactor: 테스트 더블 클래스 이름을 통일한다.

### DIFF
--- a/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/service/DomainServiceTest.java
@@ -18,7 +18,7 @@ import com.seong.shoutlink.domain.domain.service.response.UpdateDomainResponse;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.repository.FakeLinkRepository;
+import com.seong.shoutlink.domain.link.repository.StubLinkRepository;
 import com.seong.shoutlink.fixture.DomainFixture.DomainFixture;
 import com.seong.shoutlink.fixture.LinkFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class DomainServiceTest {
 
     StubDomainRepository domainRepository;
-    FakeLinkRepository linkRepository;
+    StubLinkRepository linkRepository;
     DomainService domainService;
 
     @Nested
@@ -39,7 +39,7 @@ class DomainServiceTest {
         @BeforeEach
         void setUp() {
             domainRepository = new StubDomainRepository();
-            linkRepository = new FakeLinkRepository();
+            linkRepository = new StubLinkRepository();
             domainService = new DomainService(domainRepository, linkRepository);
         }
 
@@ -98,7 +98,7 @@ class DomainServiceTest {
         @BeforeEach
         void setUp() {
             domainRepository = new StubDomainRepository();
-            linkRepository = new FakeLinkRepository();
+            linkRepository = new StubLinkRepository();
             domainService = new DomainService(domainRepository, linkRepository);
         }
 
@@ -127,7 +127,7 @@ class DomainServiceTest {
         @BeforeEach
         void setUp() {
             domainRepository = new StubDomainRepository();
-            linkRepository = new FakeLinkRepository();
+            linkRepository = new StubLinkRepository();
             domainService = new DomainService(domainRepository, linkRepository);
         }
 
@@ -157,7 +157,7 @@ class DomainServiceTest {
         @BeforeEach
         void setUp() {
             domainRepository = new StubDomainRepository();
-            linkRepository = new FakeLinkRepository();
+            linkRepository = new StubLinkRepository();
             domainService = new DomainService(domainRepository, linkRepository);
         }
 
@@ -200,7 +200,7 @@ class DomainServiceTest {
         @BeforeEach
         void setUp() {
             domainRepository = new StubDomainRepository();
-            linkRepository = new FakeLinkRepository();
+            linkRepository = new StubLinkRepository();
             domainService = new DomainService(domainRepository, linkRepository);
         }
 

--- a/src/test/java/com/seong/shoutlink/domain/link/repository/StubLinkRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/repository/StubLinkRepository.java
@@ -12,11 +12,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class FakeLinkRepository implements LinkRepository {
+public class StubLinkRepository implements LinkRepository {
 
     private final Map<Long, Link> memory = new HashMap<>();
 
-    public FakeLinkRepository(Link... links) {
+    public StubLinkRepository(Link... links) {
         stub(links);
     }
 

--- a/src/test/java/com/seong/shoutlink/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/service/LinkServiceTest.java
@@ -9,7 +9,7 @@ import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.hubmember.repository.StubHubMemberRepository;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.repository.FakeLinkRepository;
+import com.seong.shoutlink.domain.link.repository.StubLinkRepository;
 import com.seong.shoutlink.domain.link.service.request.CreateHubLinkCommand;
 import com.seong.shoutlink.domain.link.service.request.CreateLinkCommand;
 import com.seong.shoutlink.domain.link.service.request.FindHubLinksCommand;
@@ -18,7 +18,7 @@ import com.seong.shoutlink.domain.link.service.response.CreateHubLinkResponse;
 import com.seong.shoutlink.domain.link.service.response.CreateLinkResponse;
 import com.seong.shoutlink.domain.link.service.response.FindLinksResponse;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
-import com.seong.shoutlink.domain.linkbundle.repository.FakeLinkBundleRepository;
+import com.seong.shoutlink.domain.linkbundle.repository.StubLinkBundleRepository;
 import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.member.MemberRole;
 import com.seong.shoutlink.domain.member.repository.StubMemberRepository;
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.Test;
 class LinkServiceTest {
 
     private StubMemberRepository memberRepository;
-    private FakeLinkRepository linkRepository;
-    private FakeLinkBundleRepository linkBundleRepository;
+    private StubLinkRepository linkRepository;
+    private StubLinkBundleRepository linkBundleRepository;
     private StubHubRepository hubRepository;
     private StubHubMemberRepository hubMemberRepository;
     private StubEventPublisher eventPublisher;
@@ -47,8 +47,8 @@ class LinkServiceTest {
         memberRepository = new StubMemberRepository();
         hubRepository = new StubHubRepository();
         hubMemberRepository = new StubHubMemberRepository();
-        linkRepository = new FakeLinkRepository();
-        linkBundleRepository = new FakeLinkBundleRepository();
+        linkRepository = new StubLinkRepository();
+        linkBundleRepository = new StubLinkBundleRepository();
         eventPublisher = new StubEventPublisher();
         linkService = new LinkService(memberRepository, hubRepository, hubMemberRepository,
             linkRepository, linkBundleRepository, eventPublisher);
@@ -144,8 +144,8 @@ class LinkServiceTest {
             memberRepository = new StubMemberRepository();
             hubRepository = new StubHubRepository();
             hubMemberRepository = new StubHubMemberRepository();
-            linkRepository = new FakeLinkRepository();
-            linkBundleRepository = new FakeLinkBundleRepository();
+            linkRepository = new StubLinkRepository();
+            linkBundleRepository = new StubLinkBundleRepository();
             eventPublisher = new StubEventPublisher();
             linkService = new LinkService(memberRepository, hubRepository, hubMemberRepository,
                 linkRepository, linkBundleRepository, eventPublisher);
@@ -262,8 +262,8 @@ class LinkServiceTest {
             memberRepository = new StubMemberRepository();
             hubRepository = new StubHubRepository();
             hubMemberRepository = new StubHubMemberRepository();
-            linkBundleRepository = new FakeLinkBundleRepository();
-            linkRepository = new FakeLinkRepository();
+            linkBundleRepository = new StubLinkBundleRepository();
+            linkRepository = new StubLinkRepository();
             eventPublisher = new StubEventPublisher();
             linkService = new LinkService(memberRepository, hubRepository, hubMemberRepository,
                 linkRepository, linkBundleRepository, eventPublisher);

--- a/src/test/java/com/seong/shoutlink/domain/linkbundle/repository/StubLinkBundleRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/linkbundle/repository/StubLinkBundleRepository.java
@@ -11,11 +11,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class FakeLinkBundleRepository implements LinkBundleRepository {
+public class StubLinkBundleRepository implements LinkBundleRepository {
 
     private final Map<Long, LinkBundle> memory = new HashMap<>();
 
-    public FakeLinkBundleRepository(LinkBundle... linkBundles) {
+    public StubLinkBundleRepository(LinkBundle... linkBundles) {
         for (LinkBundle linkBundle : linkBundles) {
             memory.put(getNextId(), linkBundle);
         }

--- a/src/test/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/linkbundle/service/LinkBundleServiceTest.java
@@ -8,7 +8,7 @@ import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.hubmember.repository.StubHubMemberRepository;
 import com.seong.shoutlink.domain.linkbundle.LinkBundle;
-import com.seong.shoutlink.domain.linkbundle.repository.FakeLinkBundleRepository;
+import com.seong.shoutlink.domain.linkbundle.repository.StubLinkBundleRepository;
 import com.seong.shoutlink.domain.linkbundle.service.request.CreateHubLinkBundleCommand;
 import com.seong.shoutlink.domain.linkbundle.service.request.FindHubLinkBundlesCommand;
 import com.seong.shoutlink.domain.linkbundle.service.request.FindLinkBundlesCommand;
@@ -33,7 +33,7 @@ class LinkBundleServiceTest {
 
     private LinkBundleService linkBundleService;
     private StubMemberRepository memberRepository;
-    private FakeLinkBundleRepository linkBundleRepository;
+    private StubLinkBundleRepository linkBundleRepository;
     private StubHubRepository hubRepository;
     private StubHubMemberRepository hubMemberRepository;
 
@@ -47,7 +47,7 @@ class LinkBundleServiceTest {
         void setUp() {
             savedMember = MemberFixture.member();
             memberRepository = new StubMemberRepository(savedMember);
-            linkBundleRepository = new FakeLinkBundleRepository();
+            linkBundleRepository = new StubLinkBundleRepository();
             hubRepository = new StubHubRepository();
             hubMemberRepository = new StubHubMemberRepository();
             linkBundleService = new LinkBundleService(memberRepository, hubRepository,
@@ -100,7 +100,7 @@ class LinkBundleServiceTest {
         @BeforeEach
         void setUp() {
             memberRepository = new StubMemberRepository();
-            linkBundleRepository = new FakeLinkBundleRepository();
+            linkBundleRepository = new StubLinkBundleRepository();
             hubRepository = new StubHubRepository();
             hubMemberRepository = new StubHubMemberRepository();
             linkBundleService = new LinkBundleService(memberRepository, hubRepository,
@@ -141,7 +141,7 @@ class LinkBundleServiceTest {
         void setUp() {
             memberRepository = new StubMemberRepository();
             hubRepository = new StubHubRepository();
-            linkBundleRepository = new FakeLinkBundleRepository();
+            linkBundleRepository = new StubLinkBundleRepository();
             hubMemberRepository = new StubHubMemberRepository();
             linkBundleService = new LinkBundleService(memberRepository, hubRepository,
                 hubMemberRepository, linkBundleRepository);
@@ -219,7 +219,7 @@ class LinkBundleServiceTest {
         void setUp() {
             memberRepository = new StubMemberRepository();
             hubRepository = new StubHubRepository();
-            linkBundleRepository = new FakeLinkBundleRepository();
+            linkBundleRepository = new StubLinkBundleRepository();
             hubMemberRepository = new StubHubMemberRepository();
             linkBundleService = new LinkBundleService(memberRepository, hubRepository,
                 hubMemberRepository, linkBundleRepository);

--- a/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
@@ -9,8 +9,8 @@ import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.hub.repository.StubHubRepository;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.repository.FakeLinkRepository;
-import com.seong.shoutlink.domain.linkbundle.repository.FakeLinkBundleRepository;
+import com.seong.shoutlink.domain.link.repository.StubLinkRepository;
+import com.seong.shoutlink.domain.linkbundle.repository.StubLinkBundleRepository;
 import com.seong.shoutlink.domain.member.repository.StubMemberRepository;
 import com.seong.shoutlink.domain.tag.Tag;
 import com.seong.shoutlink.domain.tag.repository.StubTagRepository;
@@ -39,8 +39,8 @@ class TagServiceTest {
     StubTagRepository tagRepository;
     StubHubRepository hubRepository;
     StubMemberRepository memberRepository;
-    FakeLinkBundleRepository linkBundleRepository;
-    FakeLinkRepository linkRepository;
+    StubLinkBundleRepository linkBundleRepository;
+    StubLinkRepository linkRepository;
     AutoGenerativeClient autoGenerativeClient;
 
     @BeforeEach
@@ -48,8 +48,8 @@ class TagServiceTest {
         tagRepository = new StubTagRepository();
         hubRepository = new StubHubRepository();
         memberRepository = new StubMemberRepository();
-        linkBundleRepository = new FakeLinkBundleRepository();
-        linkRepository = new FakeLinkRepository();
+        linkBundleRepository = new StubLinkBundleRepository();
+        linkRepository = new StubLinkRepository();
         ObjectMapper objectMapper = new ObjectMapper().configure(
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         StubApiClient apiClient = new StubApiClient();


### PR DESCRIPTION
## 작업 내용

- 링크, 링크 묶음 리포지터리 테스트 더블인 `FakeLinkRepository`, `FakeLinkBundleRepository`의 이름을 `StubLinkRepository`, `StubLinkBundleRepository`로 변경하였습니다.