### PR TITLE
Refactor: 회원 생성의 책임을 회원 서비스로 이동한다. 

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/seong/shoutlink/domain/auth/controller/AuthController.java
@@ -1,17 +1,13 @@
 package com.seong.shoutlink.domain.auth.controller;
 
-import com.seong.shoutlink.domain.auth.controller.request.CreateMemberRequest;
 import com.seong.shoutlink.domain.auth.controller.request.LoginRequest;
 import com.seong.shoutlink.domain.auth.controller.response.LoginApiResponse;
 import com.seong.shoutlink.domain.auth.service.AuthUseCase;
-import com.seong.shoutlink.domain.auth.service.request.CreateMemberCommand;
 import com.seong.shoutlink.domain.auth.service.request.LoginCommand;
-import com.seong.shoutlink.domain.auth.service.response.CreateMemberResponse;
 import com.seong.shoutlink.domain.auth.service.response.LoginResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,17 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthUseCase authUseCase;
-
-    @PostMapping("/members")
-    public ResponseEntity<CreateMemberResponse> createMember(
-        @Valid @RequestBody CreateMemberRequest request) {
-        CreateMemberResponse response = authUseCase.createMember(new CreateMemberCommand(
-            request.email(),
-            request.password(),
-            request.nickname()
-        ));
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
 
     @PostMapping("/login")
     public ResponseEntity<LoginApiResponse> login(

--- a/src/main/java/com/seong/shoutlink/domain/auth/service/AuthService.java
+++ b/src/main/java/com/seong/shoutlink/domain/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.seong.shoutlink.domain.auth.service;
 
 import com.seong.shoutlink.domain.auth.JwtProvider;
-import com.seong.shoutlink.domain.auth.PasswordEncoder;
+import com.seong.shoutlink.domain.member.service.PasswordEncoder;
 import com.seong.shoutlink.domain.auth.service.request.LoginCommand;
 import com.seong.shoutlink.domain.auth.service.response.LoginResponse;
 import com.seong.shoutlink.domain.auth.service.response.TokenResponse;

--- a/src/main/java/com/seong/shoutlink/domain/auth/service/AuthService.java
+++ b/src/main/java/com/seong/shoutlink/domain/auth/service/AuthService.java
@@ -2,63 +2,23 @@ package com.seong.shoutlink.domain.auth.service;
 
 import com.seong.shoutlink.domain.auth.JwtProvider;
 import com.seong.shoutlink.domain.auth.PasswordEncoder;
-import com.seong.shoutlink.domain.auth.service.event.CreateMemberEvent;
-import com.seong.shoutlink.domain.auth.service.request.CreateMemberCommand;
 import com.seong.shoutlink.domain.auth.service.request.LoginCommand;
-import com.seong.shoutlink.domain.auth.service.response.CreateMemberResponse;
 import com.seong.shoutlink.domain.auth.service.response.LoginResponse;
 import com.seong.shoutlink.domain.auth.service.response.TokenResponse;
-import com.seong.shoutlink.domain.common.EventPublisher;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.member.Member;
-import com.seong.shoutlink.domain.member.MemberRole;
 import com.seong.shoutlink.domain.member.service.MemberRepository;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService implements AuthUseCase {
 
-    private static final Pattern PASSWORD_PATTEN = Pattern.compile(
-        "^(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).{8,20}$");
-
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
-    private final EventPublisher eventPublisher;
-
-    private void validatePassword(CreateMemberCommand command) {
-        if(!PASSWORD_PATTEN.matcher(command.password()).matches()) {
-            throw new ShoutLinkException("비밀번호는 영어 소문자, 특수문자, 숫자 8자 이상, 20자 이하여야 합니다.",
-                ErrorCode.ILLEGAL_ARGUMENT);
-        }
-    }
-
-    @Override
-    @Transactional
-    public CreateMemberResponse createMember(CreateMemberCommand command) {
-        validatePassword(command);
-        memberRepository.findByEmail(command.email())
-                .ifPresent(member -> {
-                    throw new ShoutLinkException("중복된 이메일입니다.", ErrorCode.DUPLICATE_EMAIL);
-                });
-        memberRepository.findByNickname(command.nickname())
-            .ifPresent(member -> {
-                throw new ShoutLinkException("중복된 닉네임입니다.", ErrorCode.DUPLICATE_NICKNAME);
-            });
-        Member member = new Member(
-            command.email(),
-            passwordEncoder.encode(command.password()),
-            command.nickname(),
-            MemberRole.ROLE_USER);
-        Long memberId = memberRepository.save(member);
-        eventPublisher.publishEvent(new CreateMemberEvent(memberId));
-        return new CreateMemberResponse(memberId);
-    }
 
     @Override
     public LoginResponse login(LoginCommand command) {

--- a/src/main/java/com/seong/shoutlink/domain/auth/service/AuthUseCase.java
+++ b/src/main/java/com/seong/shoutlink/domain/auth/service/AuthUseCase.java
@@ -1,13 +1,9 @@
 package com.seong.shoutlink.domain.auth.service;
 
-import com.seong.shoutlink.domain.auth.service.request.CreateMemberCommand;
 import com.seong.shoutlink.domain.auth.service.request.LoginCommand;
-import com.seong.shoutlink.domain.auth.service.response.CreateMemberResponse;
 import com.seong.shoutlink.domain.auth.service.response.LoginResponse;
 
 public interface AuthUseCase {
-
-    CreateMemberResponse createMember(CreateMemberCommand command);
 
     LoginResponse login(LoginCommand command);
 }

--- a/src/main/java/com/seong/shoutlink/domain/auth/service/response/CreateMemberResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/auth/service/response/CreateMemberResponse.java
@@ -1,5 +1,0 @@
-package com.seong.shoutlink.domain.auth.service.response;
-
-public record CreateMemberResponse(Long memberId) {
-
-}

--- a/src/main/java/com/seong/shoutlink/domain/member/controller/MemberController.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.seong.shoutlink.domain.member.controller;
+
+import com.seong.shoutlink.domain.member.controller.request.CreateMemberRequest;
+import com.seong.shoutlink.domain.member.service.MemberUseCase;
+import com.seong.shoutlink.domain.member.service.request.CreateMemberCommand;
+import com.seong.shoutlink.domain.member.service.response.CreateMemberResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemberController {
+
+    private final MemberUseCase memberUseCase;
+
+    @PostMapping("/members")
+    public ResponseEntity<CreateMemberResponse> createMember(
+        @Valid @RequestBody CreateMemberRequest request) {
+        CreateMemberResponse response = memberUseCase.createMember(new CreateMemberCommand(
+            request.email(),
+            request.password(),
+            request.nickname()
+        ));
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/member/controller/request/CreateMemberRequest.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/controller/request/CreateMemberRequest.java
@@ -1,4 +1,4 @@
-package com.seong.shoutlink.domain.auth.controller.request;
+package com.seong.shoutlink.domain.member.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/com/seong/shoutlink/domain/member/service/MemberService.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/MemberService.java
@@ -1,0 +1,56 @@
+package com.seong.shoutlink.domain.member.service;
+
+import com.seong.shoutlink.domain.auth.PasswordEncoder;
+import com.seong.shoutlink.domain.member.service.event.CreateMemberEvent;
+import com.seong.shoutlink.domain.common.EventPublisher;
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.MemberRole;
+import com.seong.shoutlink.domain.member.service.request.CreateMemberCommand;
+import com.seong.shoutlink.domain.member.service.response.CreateMemberResponse;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService implements MemberUseCase {
+
+    private static final Pattern PASSWORD_PATTEN = Pattern.compile(
+        "^(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).{8,20}$");
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EventPublisher eventPublisher;
+
+    @Transactional
+    @Override
+    public CreateMemberResponse createMember(CreateMemberCommand command) {
+        validatePassword(command.password());
+        memberRepository.findByEmail(command.email())
+            .ifPresent(member -> {
+                throw new ShoutLinkException("중복된 이메일입니다.", ErrorCode.DUPLICATE_EMAIL);
+            });
+        memberRepository.findByNickname(command.nickname())
+            .ifPresent(member -> {
+                throw new ShoutLinkException("중복된 닉네임입니다.", ErrorCode.DUPLICATE_NICKNAME);
+            });
+        Member member = new Member(
+            command.email(),
+            passwordEncoder.encode(command.password()),
+            command.nickname(),
+            MemberRole.ROLE_USER);
+        Long memberId = memberRepository.save(member);
+        eventPublisher.publishEvent(new CreateMemberEvent(memberId));
+        return new CreateMemberResponse(memberId);
+    }
+
+    private void validatePassword(String rawPassword) {
+        if(!PASSWORD_PATTEN.matcher(rawPassword).matches()) {
+            throw new ShoutLinkException("비밀번호는 영어 소문자, 특수문자, 숫자 8자 이상, 20자 이하여야 합니다.",
+                ErrorCode.ILLEGAL_ARGUMENT);
+        }
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/member/service/MemberService.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.seong.shoutlink.domain.member.service;
 
-import com.seong.shoutlink.domain.auth.PasswordEncoder;
 import com.seong.shoutlink.domain.member.service.event.CreateMemberEvent;
 import com.seong.shoutlink.domain.common.EventPublisher;
 import com.seong.shoutlink.domain.exception.ErrorCode;

--- a/src/main/java/com/seong/shoutlink/domain/member/service/MemberUseCase.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/MemberUseCase.java
@@ -1,0 +1,10 @@
+package com.seong.shoutlink.domain.member.service;
+
+import com.seong.shoutlink.domain.member.service.request.CreateMemberCommand;
+import com.seong.shoutlink.domain.member.service.response.CreateMemberResponse;
+
+public interface MemberUseCase {
+
+    CreateMemberResponse createMember(CreateMemberCommand command);
+
+}

--- a/src/main/java/com/seong/shoutlink/domain/member/service/PasswordEncoder.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/PasswordEncoder.java
@@ -1,4 +1,4 @@
-package com.seong.shoutlink.domain.auth;
+package com.seong.shoutlink.domain.member.service;
 
 public interface PasswordEncoder {
 

--- a/src/main/java/com/seong/shoutlink/domain/member/service/event/CreateMemberEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/event/CreateMemberEvent.java
@@ -1,4 +1,4 @@
-package com.seong.shoutlink.domain.auth.service.event;
+package com.seong.shoutlink.domain.member.service.event;
 
 import com.seong.shoutlink.domain.common.Event;
 

--- a/src/main/java/com/seong/shoutlink/domain/member/service/request/CreateMemberCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/request/CreateMemberCommand.java
@@ -1,4 +1,4 @@
-package com.seong.shoutlink.domain.auth.service.request;
+package com.seong.shoutlink.domain.member.service.request;
 
 public record CreateMemberCommand(String email, String password, String nickname) {
 

--- a/src/main/java/com/seong/shoutlink/domain/member/service/response/CreateMemberResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/member/service/response/CreateMemberResponse.java
@@ -1,0 +1,5 @@
+package com.seong.shoutlink.domain.member.service.response;
+
+public record CreateMemberResponse(Long memberId) {
+
+}

--- a/src/main/java/com/seong/shoutlink/global/auth/crypto/BCryptPasswordEncoder.java
+++ b/src/main/java/com/seong/shoutlink/global/auth/crypto/BCryptPasswordEncoder.java
@@ -1,6 +1,6 @@
 package com.seong.shoutlink.global.auth.crypto;
 
-import com.seong.shoutlink.domain.auth.PasswordEncoder;
+import com.seong.shoutlink.domain.member.service.PasswordEncoder;
 import org.mindrot.jbcrypt.BCrypt;
 
 public class BCryptPasswordEncoder implements PasswordEncoder {

--- a/src/main/java/com/seong/shoutlink/global/config/AuthConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/AuthConfig.java
@@ -1,7 +1,7 @@
 package com.seong.shoutlink.global.config;
 
 import com.seong.shoutlink.domain.auth.JwtProvider;
-import com.seong.shoutlink.domain.auth.PasswordEncoder;
+import com.seong.shoutlink.domain.member.service.PasswordEncoder;
 import com.seong.shoutlink.global.auth.authentication.AuthenticationContext;
 import com.seong.shoutlink.global.auth.authentication.JwtAuthenticationProvider;
 import com.seong.shoutlink.global.auth.crypto.BCryptPasswordEncoder;

--- a/src/main/java/com/seong/shoutlink/global/event/LinkBundleEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/LinkBundleEventListener.java
@@ -1,6 +1,6 @@
 package com.seong.shoutlink.global.event;
 
-import com.seong.shoutlink.domain.auth.service.event.CreateMemberEvent;
+import com.seong.shoutlink.domain.member.service.event.CreateMemberEvent;
 import com.seong.shoutlink.domain.hub.service.event.CreateHubEvent;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleUseCase;
 import com.seong.shoutlink.domain.linkbundle.service.request.CreateHubLinkBundleCommand;

--- a/src/test/java/com/seong/shoutlink/base/BaseControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/base/BaseControllerTest.java
@@ -11,6 +11,7 @@ import com.seong.shoutlink.domain.hub.service.HubService;
 import com.seong.shoutlink.domain.link.service.LinkService;
 import com.seong.shoutlink.domain.linkbundle.service.LinkBundleService;
 import com.seong.shoutlink.domain.member.MemberRole;
+import com.seong.shoutlink.domain.member.service.MemberService;
 import com.seong.shoutlink.fixture.AuthFixture;
 import com.seong.shoutlink.global.auth.authentication.AuthenticationContext;
 import com.seong.shoutlink.global.auth.authentication.JwtAuthenticationProvider;
@@ -65,6 +66,9 @@ public class BaseControllerTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected MemberService memberService;
 
     @MockBean
     protected AuthService authService;

--- a/src/test/java/com/seong/shoutlink/domain/auth/FakePasswordEncoder.java
+++ b/src/test/java/com/seong/shoutlink/domain/auth/FakePasswordEncoder.java
@@ -1,6 +1,8 @@
 package com.seong.shoutlink.domain.auth;
 
-public class FakePasswordEncoder implements PasswordEncoder{
+import com.seong.shoutlink.domain.member.service.PasswordEncoder;
+
+public class FakePasswordEncoder implements PasswordEncoder {
 
     @Override
     public String encode(String rawPassword) {

--- a/src/test/java/com/seong/shoutlink/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/auth/controller/AuthControllerTest.java
@@ -13,9 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.seong.shoutlink.base.BaseControllerTest;
-import com.seong.shoutlink.domain.auth.controller.request.CreateMemberRequest;
 import com.seong.shoutlink.domain.auth.controller.request.LoginRequest;
-import com.seong.shoutlink.domain.auth.service.response.CreateMemberResponse;
 import com.seong.shoutlink.domain.auth.service.response.LoginResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,34 +22,6 @@ import org.springframework.test.web.servlet.ResultActions;
 
 class AuthControllerTest extends BaseControllerTest {
 
-    @Test
-    @DisplayName("성공: 회원 등록 api 호출")
-    void createMember() throws Exception {
-        //given
-        CreateMemberRequest createMemberRequest = new CreateMemberRequest("email@email.com",
-            "asdf1234!", "닉네임");
-        CreateMemberResponse createMemberResponse = new CreateMemberResponse(1L);
-
-        given(authService.createMember(any())).willReturn(createMemberResponse);
-
-        //when
-        ResultActions resultActions = mockMvc.perform(post("/api/members")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(createMemberRequest)));
-
-        //then
-        resultActions.andExpect(status().isCreated())
-            .andDo(restDocs.document(
-                requestFields(
-                    fieldWithPath("email").type(STRING).description("사용자 이메일"),
-                    fieldWithPath("password").type(STRING).description("사용자 비밀번호"),
-                    fieldWithPath("nickname").type(STRING).description("사용자 닉네임")
-                ),
-                responseFields(
-                    fieldWithPath("memberId").type(NUMBER).description("사용자 ID")
-                )
-            ));
-    }
     @Test
     @DisplayName("성공: 로그인 api 호출")
     void login() throws Exception {

--- a/src/test/java/com/seong/shoutlink/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/auth/service/AuthServiceTest.java
@@ -5,11 +5,8 @@ import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.shoutlink.domain.auth.FakePasswordEncoder;
 import com.seong.shoutlink.domain.auth.JwtProvider;
-import com.seong.shoutlink.domain.auth.service.request.CreateMemberCommand;
 import com.seong.shoutlink.domain.auth.service.request.LoginCommand;
-import com.seong.shoutlink.domain.auth.service.response.CreateMemberResponse;
 import com.seong.shoutlink.domain.auth.service.response.LoginResponse;
-import com.seong.shoutlink.domain.common.StubEventPublisher;
 import com.seong.shoutlink.domain.exception.ErrorCode;
 import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.member.Member;
@@ -20,8 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 class AuthServiceTest {
 
@@ -32,119 +27,6 @@ class AuthServiceTest {
         "thisisjusttestrefreshsecretsodontworry");
 
     @Nested
-    @DisplayName("회원 생성 시")
-    class CreateMemberTest {
-
-        Member savedMember;
-        StubMemberRepository memberRepository;
-        AuthService authService;
-        StubEventPublisher eventPublisher;
-
-        @BeforeEach
-        void setUp() {
-            String email = "stub@stub.com";
-            String password = "stub123!";
-            String nickname = "stub";
-            MemberRole memberRole = MemberRole.ROLE_USER;
-            savedMember = new Member(email, password, nickname, memberRole);
-            memberRepository = new StubMemberRepository(savedMember);
-            eventPublisher = new StubEventPublisher();
-            authService = new AuthService(
-                memberRepository,
-                passwordEncoder,
-                jwtProvider,
-                eventPublisher);
-        }
-
-        @ParameterizedTest
-        @CsvSource({"asdf123!", "asdfasdf12341234!@#$"})
-        @DisplayName("성공: 비밀번호가 영어 소문자, 특수문자, 숫자를 모두 포함하여 8자 이상, 20자 이하이다.")
-        void createMember(String validPassword) {
-            //given
-            CreateMemberCommand createMemberCommand
-                = new CreateMemberCommand("email@email.com", validPassword, "닉네임");
-
-            //when
-            CreateMemberResponse response = authService.createMember(createMemberCommand);
-
-            //then
-            assertThat(response.memberId()).isNotNull();
-        }
-
-        @ParameterizedTest
-        @CsvSource({"asdf", "asdf1234", "asdf!@#$", "1234!@#$", "a1!",
-            "thisisovertwentycharacters!@#$123"})
-        @DisplayName("예외(illegalArgument): 비밀번호가 잘못된 형식")
-        void invalidPassword(String invalidPassword) {
-            //given
-            CreateMemberCommand createMemberCommand
-                = new CreateMemberCommand("email@email.com", invalidPassword, "닉네임");
-
-            //when
-            Exception exception = catchException(
-                () -> authService.createMember(createMemberCommand));
-
-            //then
-            assertThat(exception)
-                .isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.ILLEGAL_ARGUMENT);
-        }
-
-        @Test
-        @DisplayName("예외(duplicateEmail): 중복된 이메일")
-        void duplicateEmail_WhenEmailIsDuplicate() {
-            //given
-            String duplicateEmail = savedMember.getEmail();
-            CreateMemberCommand createMemberCommand
-                = new CreateMemberCommand(duplicateEmail, "asdf123!", "닉네임");
-
-            //when
-            Exception exception = catchException(
-                () -> authService.createMember(createMemberCommand));
-
-            //then
-            assertThat(exception)
-                .isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
-        }
-
-        @Test
-        @DisplayName("예외(duplicateNickname): 중복된 닉네임")
-        void duplicateNickname_WhenNicknameIsDuplicate() {
-            //given
-            String duplicateNickname = savedMember.getNickname();
-            CreateMemberCommand createMemberCommand
-                = new CreateMemberCommand("asdf@asdf.com", "asdf123!", duplicateNickname);
-
-            //when
-            Exception exception = catchException(
-                () -> authService.createMember(createMemberCommand));
-
-            //then
-            assertThat(exception)
-                .isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
-        }
-
-        @Test
-        @DisplayName("성공: 회원 생성 이벤트 발행함")
-        void publishCreateMemberEvent() {
-            //given
-            CreateMemberCommand command
-                = new CreateMemberCommand("email@email.com", "asdf123!", "nickname");
-
-            //when
-            CreateMemberResponse response = authService.createMember(command);
-
-            //then
-            assertThat(eventPublisher.getPublishEventCount()).isEqualTo(1);
-        }
-    }
-
-    @Nested
     @DisplayName("로그인 메서드 호출 시")
     class LoginTest {
 
@@ -152,7 +34,6 @@ class AuthServiceTest {
         Member savedMember;
         StubMemberRepository memberRepository;
         AuthService authService;
-        StubEventPublisher eventPublisher;
 
         @BeforeEach
         void setUp() {
@@ -163,12 +44,10 @@ class AuthServiceTest {
             MemberRole memberRole = MemberRole.ROLE_USER;
             savedMember = new Member(1L, email, password, nickname, memberRole);
             memberRepository = new StubMemberRepository(savedMember);
-            eventPublisher = new StubEventPublisher();
             authService = new AuthService(
                 memberRepository,
                 passwordEncoder,
-                jwtProvider,
-                eventPublisher);
+                jwtProvider);
         }
 
         @Test

--- a/src/test/java/com/seong/shoutlink/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,51 @@
+package com.seong.shoutlink.domain.member.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.seong.shoutlink.base.BaseControllerTest;
+import com.seong.shoutlink.domain.member.controller.request.CreateMemberRequest;
+import com.seong.shoutlink.domain.member.service.response.CreateMemberResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class MemberControllerTest extends BaseControllerTest {
+
+    @Test
+    @DisplayName("성공: 회원 등록 api 호출")
+    void createMember() throws Exception {
+        //given
+        CreateMemberRequest createMemberRequest = new CreateMemberRequest("email@email.com",
+            "asdf1234!", "닉네임");
+        CreateMemberResponse createMemberResponse = new CreateMemberResponse(1L);
+
+        given(memberService.createMember(any())).willReturn(createMemberResponse);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/api/members")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(createMemberRequest)));
+
+        //then
+        resultActions.andExpect(status().isCreated())
+            .andDo(restDocs.document(
+                requestFields(
+                    fieldWithPath("email").type(STRING).description("사용자 이메일"),
+                    fieldWithPath("password").type(STRING).description("사용자 비밀번호"),
+                    fieldWithPath("nickname").type(STRING).description("사용자 닉네임")
+                ),
+                responseFields(
+                    fieldWithPath("memberId").type(NUMBER).description("사용자 ID")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,133 @@
+package com.seong.shoutlink.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.seong.shoutlink.domain.auth.FakePasswordEncoder;
+import com.seong.shoutlink.domain.common.StubEventPublisher;
+import com.seong.shoutlink.domain.exception.ErrorCode;
+import com.seong.shoutlink.domain.exception.ShoutLinkException;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.repository.StubMemberRepository;
+import com.seong.shoutlink.domain.member.service.request.CreateMemberCommand;
+import com.seong.shoutlink.domain.member.service.response.CreateMemberResponse;
+import com.seong.shoutlink.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class MemberServiceTest {
+
+    MemberService memberService;
+    StubMemberRepository memberRepository;
+    FakePasswordEncoder passwordEncoder;
+    StubEventPublisher eventPublisher;
+
+    @Nested
+    @DisplayName("createMember 호출 시")
+    class CreateMemberTest {
+
+        @BeforeEach
+        void setUp() {
+            memberRepository = new StubMemberRepository();
+            passwordEncoder = new FakePasswordEncoder();
+            eventPublisher = new StubEventPublisher();
+            memberService = new MemberService(memberRepository, passwordEncoder, eventPublisher);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"asdf123!", "asdfasdf12341234!@#$"})
+        @DisplayName("성공: 비밀번호가 영어 소문자, 특수문자, 숫자를 모두 포함하여 8자 이상, 20자 이하이다.")
+        void createMember(String validPassword) {
+            //given
+            CreateMemberCommand createMemberCommand
+                = new CreateMemberCommand("email@email.com", validPassword, "닉네임");
+
+            //when
+            CreateMemberResponse response = memberService.createMember(createMemberCommand);
+
+            //then
+            assertThat(response.memberId()).isNotNull();
+        }
+
+        @ParameterizedTest
+        @CsvSource({"asdf", "asdf1234", "asdf!@#$", "1234!@#$", "a1!",
+            "thisisovertwentycharacters!@#$123"})
+        @DisplayName("예외(illegalArgument): 비밀번호가 잘못된 형식")
+        void invalidPassword(String invalidPassword) {
+            //given
+            CreateMemberCommand createMemberCommand
+                = new CreateMemberCommand("email@email.com", invalidPassword, "닉네임");
+
+            //when
+            Exception exception = catchException(
+                () -> memberService.createMember(createMemberCommand));
+
+            //then
+            assertThat(exception)
+                .isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ILLEGAL_ARGUMENT);
+        }
+
+        @Test
+        @DisplayName("예외(duplicateEmail): 중복된 이메일")
+        void duplicateEmail_WhenEmailIsDuplicate() {
+            //given
+            Member member = MemberFixture.member();
+            memberRepository.stub(member);
+            String duplicateEmail = member.getEmail();
+            CreateMemberCommand createMemberCommand
+                = new CreateMemberCommand(duplicateEmail, "asdf123!", "닉네임");
+
+            //when
+            Exception exception = catchException(
+                () -> memberService.createMember(createMemberCommand));
+
+            //then
+            assertThat(exception)
+                .isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        @Test
+        @DisplayName("예외(duplicateNickname): 중복된 닉네임")
+        void duplicateNickname_WhenNicknameIsDuplicate() {
+            //given
+            Member member = MemberFixture.member();
+            memberRepository.stub(member);
+            String duplicateNickname = member.getNickname();
+            CreateMemberCommand createMemberCommand
+                = new CreateMemberCommand("asdf@asdf.com", "asdf123!", duplicateNickname);
+
+            //when
+            Exception exception = catchException(
+                () -> memberService.createMember(createMemberCommand));
+
+            //then
+            assertThat(exception)
+                .isInstanceOf(ShoutLinkException.class)
+                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        @Test
+        @DisplayName("성공: 회원 생성 이벤트 발행함")
+        void publishCreateMemberEvent() {
+            //given
+            CreateMemberCommand command
+                = new CreateMemberCommand("email@email.com", "asdf123!", "nickname");
+
+            //when
+            CreateMemberResponse response = memberService.createMember(command);
+
+            //then
+            assertThat(eventPublisher.getPublishEventCount()).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/fixture/MemberFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/MemberFixture.java
@@ -1,7 +1,7 @@
 package com.seong.shoutlink.fixture;
 
 import com.seong.shoutlink.domain.auth.FakePasswordEncoder;
-import com.seong.shoutlink.domain.auth.PasswordEncoder;
+import com.seong.shoutlink.domain.member.service.PasswordEncoder;
 import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.member.MemberRole;
 

--- a/src/test/java/com/seong/shoutlink/global/event/LinkBundleEventListenerTest.java
+++ b/src/test/java/com/seong/shoutlink/global/event/LinkBundleEventListenerTest.java
@@ -3,14 +3,14 @@ package com.seong.shoutlink.global.event;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.seong.shoutlink.base.BaseIntegrationTest;
-import com.seong.shoutlink.domain.auth.service.AuthService;
-import com.seong.shoutlink.domain.auth.service.request.CreateMemberCommand;
 import com.seong.shoutlink.domain.hub.service.HubService;
 import com.seong.shoutlink.domain.hub.service.request.CreateHubCommand;
 import com.seong.shoutlink.domain.hub.service.response.CreateHubResponse;
 import com.seong.shoutlink.domain.linkbundle.repository.LinkBundleEntity;
 import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.member.service.MemberRepository;
+import com.seong.shoutlink.domain.member.service.MemberService;
+import com.seong.shoutlink.domain.member.service.request.CreateMemberCommand;
 import com.seong.shoutlink.fixture.MemberFixture;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +23,7 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 class LinkBundleEventListenerTest extends BaseIntegrationTest {
 
     @Autowired
-    private AuthService authService;
+    private MemberService memberService;
 
     @Autowired
     private HubService hubService;
@@ -49,7 +49,7 @@ class LinkBundleEventListenerTest extends BaseIntegrationTest {
                 member.getNickname());
 
             //when
-            authService.createMember(createMemberCommand);
+            memberService.createMember(createMemberCommand);
 
             //then
             LinkBundleEntity linkBundleEntity = em.createQuery(


### PR DESCRIPTION
## 작업 내용

- 회원 생성의 책임을 인증 서비스에서 새롭게 만든 회원 서비스로 이동하였습니다.
- 패스워드 인코더 인터페이스를 회원 패키지로 이동하였습니다.