### PR TITLE
Refactor: 루트 도메인 문자열 캐싱 전략을 변경한다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/common/Trie.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/Trie.java
@@ -3,6 +3,7 @@ package com.seong.shoutlink.domain.common;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 
@@ -28,8 +29,9 @@ public class Trie {
         }
 
         public Node nextNode(char c) {
-            children.putIfAbsent(c, new Node(c));
-            return children.get(c);
+            Node nextNode = children.putIfAbsent(c, new Node(c));
+            return Optional.ofNullable(nextNode)
+                .orElseGet(() -> children.get(c));
         }
 
         public void addSuggestions(String word, List<String> suggestions, int count) {

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -40,7 +40,6 @@ public class DomainRepositoryImpl implements DomainRepository {
         return domainCacheRepository.findRootDomains(keyword, size);
     }
 
-    @Override
     public void synchronizeRootDomains() {
         domainJpaRepository.findRootDomains().forEach(domainCacheRepository::insert);
     }

--- a/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImpl.java
@@ -29,8 +29,10 @@ public class DomainRepositoryImpl implements DomainRepository {
 
     @Override
     public Domain save(Domain domain) {
-        return domainJpaRepository.save(DomainEntity.create(domain))
+        Domain savedDomain = domainJpaRepository.save(DomainEntity.create(domain))
             .toDomain();
+        domainCacheRepository.insert(savedDomain.getRootDomain());
+        return savedDomain;
     }
 
     @Override

--- a/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/domain/service/DomainRepository.java
@@ -14,8 +14,6 @@ public interface DomainRepository {
 
     List<String> findRootDomains(String keyword, int size);
 
-    void synchronizeRootDomains();
-
     DomainPaginationResult findDomains(String keyword, int page, int size);
 
     Optional<Domain> findById(Long domainId);

--- a/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/EventConfig.java
@@ -1,6 +1,7 @@
 package com.seong.shoutlink.global.config;
 
 import com.seong.shoutlink.domain.common.EventPublisher;
+import com.seong.shoutlink.domain.domain.repository.DomainRepositoryImpl;
 import com.seong.shoutlink.domain.domain.service.DomainUseCase;
 import com.seong.shoutlink.domain.link.service.LinkBundleUseCase;
 import com.seong.shoutlink.domain.tag.service.TagUseCase;
@@ -26,8 +27,10 @@ public class EventConfig {
     }
 
     @Bean
-    public DomainEventListener domainEventListener(DomainUseCase domainUseCase) {
-        return new DomainEventListener(domainUseCase);
+    public DomainEventListener domainEventListener(
+        DomainUseCase domainUseCase,
+        DomainRepositoryImpl domainRepository) {
+        return new DomainEventListener(domainUseCase, domainRepository);
     }
 
     @Bean

--- a/src/main/java/com/seong/shoutlink/global/config/SchedulerConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/SchedulerConfig.java
@@ -1,6 +1,6 @@
 package com.seong.shoutlink.global.config;
 
-import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import com.seong.shoutlink.domain.domain.repository.DomainRepositoryImpl;
 import com.seong.shoutlink.global.scheduler.DomainScheduler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class SchedulerConfig {
 
     @Bean
-    public DomainScheduler domainScheduler(DomainRepository domainRepository) {
+    public DomainScheduler domainScheduler(DomainRepositoryImpl domainRepository) {
         return new DomainScheduler(domainRepository);
     }
 }

--- a/src/main/java/com/seong/shoutlink/global/event/DomainEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/DomainEventListener.java
@@ -1,9 +1,12 @@
 package com.seong.shoutlink.global.event;
 
+import com.seong.shoutlink.domain.domain.repository.DomainRepositoryImpl;
 import com.seong.shoutlink.domain.domain.service.DomainUseCase;
 import com.seong.shoutlink.domain.domain.service.request.UpdateDomainCommand;
 import com.seong.shoutlink.domain.link.service.event.CreateLinkEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,10 +15,16 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class DomainEventListener {
 
     private final DomainUseCase domainUseCase;
+    private final DomainRepositoryImpl domainRepository;
 
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateDomainInfo(CreateLinkEvent event) {
         domainUseCase.updateDomain(new UpdateDomainCommand(event.linkId(), event.url()));
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmUpCache() {
+        domainRepository.synchronizeRootDomains();
     }
 }

--- a/src/main/java/com/seong/shoutlink/global/scheduler/DomainScheduler.java
+++ b/src/main/java/com/seong/shoutlink/global/scheduler/DomainScheduler.java
@@ -1,13 +1,13 @@
 package com.seong.shoutlink.global.scheduler;
 
-import com.seong.shoutlink.domain.domain.service.DomainRepository;
+import com.seong.shoutlink.domain.domain.repository.DomainRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 
 @RequiredArgsConstructor
 public class DomainScheduler {
 
-    private final DomainRepository domainRepository;
+    private final DomainRepositoryImpl domainRepository;
 
     @Scheduled(cron = "0 0 * * * *")
     public void synchronizeRootDomains() {

--- a/src/test/java/com/seong/shoutlink/base/BaseIntegrationTest.java
+++ b/src/test/java/com/seong/shoutlink/base/BaseIntegrationTest.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class BaseIntegrationTest {
+public abstract class BaseIntegrationTest {
 
     @Autowired
     private DatabaseCleaner databaseCleaner;

--- a/src/test/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImplTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/repository/DomainRepositoryImplTest.java
@@ -1,0 +1,36 @@
+package com.seong.shoutlink.domain.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.seong.shoutlink.base.BaseIntegrationTest;
+import com.seong.shoutlink.domain.domain.Domain;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DomainRepositoryImplTest extends BaseIntegrationTest {
+
+    @Autowired
+    private DomainRepositoryImpl domainRepository;
+
+    @Nested
+    @DisplayName("save 호출 시")
+    class SaveTest {
+
+        @Test
+        @DisplayName("성공: 루트 도메인 문자열이 캐싱된다.")
+        void cachingRootDomain() {
+            //given
+            Domain domain = new Domain("asdf");
+
+            //when
+            domainRepository.save(domain);
+
+            //then
+            List<String> rootDomains = domainRepository.findRootDomains("as", 10);
+            assertThat(rootDomains).containsExactly("asdf");
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/domain/repository/StubDomainRepository.java
@@ -76,11 +76,4 @@ public class StubDomainRepository implements DomainRepository {
     public List<String> findRootDomains(String keyword, int size) {
         return searchAutoComplete.search(keyword, size);
     }
-
-    @Override
-    public void synchronizeRootDomains() {
-        for (Domain domain : memory.values()) {
-            searchAutoComplete.insert(domain.getRootDomain());
-        }
-    }
 }


### PR DESCRIPTION
## 작업 내용

- 루트 도메인 문자열 캐싱 쓰기 전략에 write through를 적용했습니다. DomainRepositoryImpl의 save() 메서드에 캐시 insert 로직을 추가하였습니다.
- 루트 도메인 문자열 캐시 워밍업을 추가하였습니다. ApplicationReadyEvent를 바라보는 이벤트 리스너를 추가하여 애플리케이션 시작시 캐시 워밍업 동작이 일어납니다.
- Trie 구현을 개선했습니다. 기존에는 insert() 메서드에 synchronized 키워드를 이용해 동시성을 처리하였으나, Tire의 Node가 사용하는 Map 구현을 ConcurrentHashMap으로 변경하고 이를 잘 활용할 수 있도록 로직을 개선했습니다.