### PR TITLE
Refactor: 클래스 명을 일관되게 수정한다. 

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/link/LinkBundleAndLink.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/LinkBundleAndLink.java
@@ -3,12 +3,12 @@ package com.seong.shoutlink.domain.link;
 import lombok.Getter;
 
 @Getter
-public class LinkWithLinkBundle {
+public class LinkBundleAndLink {
 
     private final Link link;
     private final LinkBundle linkBundle;
 
-    public LinkWithLinkBundle(Link link, LinkBundle linkBundle) {
+    public LinkBundleAndLink(Link link, LinkBundle linkBundle) {
         this.link = link;
         this.linkBundle = linkBundle;
     }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
@@ -3,7 +3,7 @@ package com.seong.shoutlink.domain.link.repository;
 import com.seong.shoutlink.domain.common.BaseEntity;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
+import com.seong.shoutlink.domain.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.LinkBundle;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -35,9 +35,9 @@ public class LinkEntity extends BaseEntity {
         this.linkBundleId = linkBundleId;
     }
 
-    public static LinkEntity create(LinkWithLinkBundle linkWithLinkBundle) {
-        Link link = linkWithLinkBundle.getLink();
-        LinkBundle linkBundle = linkWithLinkBundle.getLinkBundle();
+    public static LinkEntity create(LinkBundleAndLink linkBundleAndLink) {
+        Link link = linkBundleAndLink.getLink();
+        LinkBundle linkBundle = linkBundleAndLink.getLinkBundle();
         return new LinkEntity(
             link.getUrl(),
             link.getDescription(),

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.seong.shoutlink.domain.link.repository;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
+import com.seong.shoutlink.domain.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.service.LinkRepository;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.link.LinkBundle;
@@ -24,8 +24,8 @@ public class LinkRepositoryImpl implements LinkRepository {
     private final LinkJpaRepository linkJpaRepository;
 
     @Override
-    public Long save(LinkWithLinkBundle linkWithLinkBundle) {
-        LinkEntity linkEntity = linkJpaRepository.save(LinkEntity.create(linkWithLinkBundle));
+    public Long save(LinkBundleAndLink linkBundleAndLink) {
+        LinkEntity linkEntity = linkJpaRepository.save(LinkEntity.create(linkBundleAndLink));
         return linkEntity.getLinkId();
     }
 
@@ -58,7 +58,7 @@ public class LinkRepositoryImpl implements LinkRepository {
     }
 
     @Override
-    public List<LinkWithLinkBundle> findAllByLinkBundlesIn(List<LinkBundle> linkBundles) {
+    public List<LinkBundleAndLink> findAllByLinkBundlesIn(List<LinkBundle> linkBundles) {
         List<Long> linkBundleIds = linkBundles.stream()
             .map(LinkBundle::getLinkBundleId)
             .toList();
@@ -66,7 +66,7 @@ public class LinkRepositoryImpl implements LinkRepository {
         Map<Long, LinkBundle> linkBundleIdAndLinkBundle = linkBundles.stream()
             .collect(Collectors.toMap(LinkBundle::getLinkBundleId, linkBundle -> linkBundle));
         return linkEntities.stream()
-            .map(linkEntity -> new LinkWithLinkBundle(linkEntity.toDomain(),
+            .map(linkEntity -> new LinkBundleAndLink(linkEntity.toDomain(),
                 linkBundleIdAndLinkBundle.get(linkEntity.getLinkBundleId())))
             .toList();
     }

--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkRepository.java
@@ -3,7 +3,7 @@ package com.seong.shoutlink.domain.link.service;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
+import com.seong.shoutlink.domain.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.link.LinkBundle;
 import com.seong.shoutlink.domain.member.Member;
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface LinkRepository {
 
-    Long save(LinkWithLinkBundle linkWithLinkBundle);
+    Long save(LinkBundleAndLink linkBundleAndLink);
 
     LinkPaginationResult findLinks(LinkBundle linkBundle, int page, int size);
 
@@ -20,7 +20,7 @@ public interface LinkRepository {
 
     Optional<Link> findById(Long linkId);
 
-    List<LinkWithLinkBundle> findAllByLinkBundlesIn(List<LinkBundle> linkBundles);
+    List<LinkBundleAndLink> findAllByLinkBundlesIn(List<LinkBundle> linkBundles);
 
     Optional<Link> findMemberLink(Long linkId, Member member);
 

--- a/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/service/LinkService.java
@@ -7,7 +7,7 @@ import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.hub.service.HubRepository;
 import com.seong.shoutlink.domain.hub.service.HubMemberRepository;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
+import com.seong.shoutlink.domain.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.service.event.CreateHubLinkEvent;
 import com.seong.shoutlink.domain.link.service.event.CreateMemberLinkEvent;
 import com.seong.shoutlink.domain.link.service.request.CreateHubLinkCommand;
@@ -47,8 +47,8 @@ public class LinkService implements LinkUseCase {
         Member member = getMember(command.memberId());
         LinkBundle linkBundle = getLinkBundle(command.linkBundleId(), member);
         Link link = new Link(command.url(), command.description());
-        LinkWithLinkBundle linkWithLinkBundle = new LinkWithLinkBundle(link, linkBundle);
-        Long linkId = linkRepository.save(linkWithLinkBundle);
+        LinkBundleAndLink linkBundleAndLink = new LinkBundleAndLink(link, linkBundle);
+        Long linkId = linkRepository.save(linkBundleAndLink);
         eventPublisher.publishEvent(
             new CreateMemberLinkEvent(linkId, link.getUrl(), member.getMemberId()));
         return new CreateLinkResponse(linkId);
@@ -85,7 +85,7 @@ public class LinkService implements LinkUseCase {
 
         LinkBundle hubLinkBundle = getHubLinkBundle(command.linkBundleId(), hub);
         Link link = new Link(command.url(), command.description());
-        Long linkId = linkRepository.save(new LinkWithLinkBundle(link, hubLinkBundle));
+        Long linkId = linkRepository.save(new LinkBundleAndLink(link, hubLinkBundle));
         eventPublisher.publishEvent(new CreateHubLinkEvent(linkId, link.getUrl(), hub.getHubId()));
         return new CreateHubLinkResponse(linkId);
     }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
@@ -9,7 +9,7 @@ import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.hub.service.HubRepository;
 import com.seong.shoutlink.domain.link.LinkBundleAndLinks;
-import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
+import com.seong.shoutlink.domain.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.service.LinkRepository;
 import com.seong.shoutlink.domain.link.LinkBundle;
 import com.seong.shoutlink.domain.link.service.LinkBundleRepository;
@@ -48,7 +48,7 @@ public class TagService implements TagUseCase {
         Hub hub = getHub(command.hubId());
         checkHubTagIsCreatedWithinADay(hub);
         List<LinkBundle> hubLinkBundles = linkBundleRepository.findHubLinkBundles(hub);
-        List<LinkWithLinkBundle> links = linkRepository.findAllByLinkBundlesIn(hubLinkBundles);
+        List<LinkBundleAndLink> links = linkRepository.findAllByLinkBundlesIn(hubLinkBundles);
 
         List<LinkBundleAndLinks> linkBundlesAndLinks = groupingLinks(links);
         int generateTagCount = calculateNumberOfTag(links);
@@ -79,7 +79,7 @@ public class TagService implements TagUseCase {
         Member member = getMember(command.memberId());
         checkMemberTagIsCreatedWithinADay(member);
         List<LinkBundle> linkBundles = linkBundleRepository.findLinkBundlesThatMembersHave(member);
-        List<LinkWithLinkBundle> links = linkRepository.findAllByLinkBundlesIn(linkBundles);
+        List<LinkBundleAndLink> links = linkRepository.findAllByLinkBundlesIn(linkBundles);
 
         List<LinkBundleAndLinks> linkBundleAndLinks = groupingLinks(links);
         int generateTagCount = calculateNumberOfTag(links);
@@ -106,17 +106,17 @@ public class TagService implements TagUseCase {
             });
     }
 
-    private List<LinkBundleAndLinks> groupingLinks(List<LinkWithLinkBundle> links) {
+    private List<LinkBundleAndLinks> groupingLinks(List<LinkBundleAndLink> links) {
         return links.stream()
             .collect(groupingBy(
-                LinkWithLinkBundle::getLinkBundle,
-                mapping(LinkWithLinkBundle::getLink, toList())))
+                LinkBundleAndLink::getLinkBundle,
+                mapping(LinkBundleAndLink::getLink, toList())))
             .entrySet().stream()
             .map(entry -> new LinkBundleAndLinks(entry.getKey(), entry.getValue()))
             .toList();
     }
 
-    private int calculateNumberOfTag(List<LinkWithLinkBundle> links) {
+    private int calculateNumberOfTag(List<LinkBundleAndLink> links) {
         int totalLinkCount = links.size();
         if (totalLinkCount < MINIMUM_TAG_CONDITION
             || totalLinkCount % MINIMUM_TAG_CONDITION != ZERO) {

--- a/src/test/java/com/seong/shoutlink/domain/link/repository/StubLinkRepository.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/repository/StubLinkRepository.java
@@ -3,7 +3,7 @@ package com.seong.shoutlink.domain.link.repository;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.LinkWithLinkBundle;
+import com.seong.shoutlink.domain.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.service.LinkRepository;
 import com.seong.shoutlink.domain.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.link.LinkBundle;
@@ -33,9 +33,9 @@ public class StubLinkRepository implements LinkRepository {
     }
 
     @Override
-    public Long save(LinkWithLinkBundle linkWithLinkBundle) {
+    public Long save(LinkBundleAndLink linkBundleAndLink) {
         long nextId = getNextId();
-        memory.put(nextId, linkWithLinkBundle.getLink());
+        memory.put(nextId, linkBundleAndLink.getLink());
         return nextId;
     }
 
@@ -63,12 +63,12 @@ public class StubLinkRepository implements LinkRepository {
     }
 
     @Override
-    public List<LinkWithLinkBundle> findAllByLinkBundlesIn(List<LinkBundle> linkBundles) {
-        List<LinkWithLinkBundle> result = new ArrayList<>();
+    public List<LinkBundleAndLink> findAllByLinkBundlesIn(List<LinkBundle> linkBundles) {
+        List<LinkBundleAndLink> result = new ArrayList<>();
         List<Link> links = memory.values().stream().toList();
         for(int i=0; i<links.size(); i++) {
             LinkBundle linkBundle = linkBundles.get(i % linkBundles.size());
-            result.add(new LinkWithLinkBundle(links.get(i), linkBundle));
+            result.add(new LinkBundleAndLink(links.get(i), linkBundle));
         }
         return result;
     }


### PR DESCRIPTION
## 작업 내용

- LinkWithLinkBundle 클래스 이름을 LinkBundleAndLink로 변경하였습니다.
- LinkBundle과 List<Link>를 멤버로 가지는 LinkBundleAndLinks와 유사한 이름 형식을 가지도록 하였습니다.