### PR TITLE
Refactor: Trie를 리팩토링한다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/common/Trie.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/Trie.java
@@ -12,13 +12,8 @@ public class Trie {
 
     static class Node {
 
-        private final char c;
         private final Map<Character, Node> children = new ConcurrentHashMap<>();
         private boolean isWord;
-
-        public Node(char c) {
-            this.c = c;
-        }
 
         public void settingWord() {
             isWord = true;
@@ -29,16 +24,16 @@ public class Trie {
         }
 
         public Node nextNode(char c) {
-            Node nextNode = children.putIfAbsent(c, new Node(c));
+            Node nextNode = children.putIfAbsent(c, new Node());
             return Optional.ofNullable(nextNode)
                 .orElseGet(() -> children.get(c));
         }
 
         public void addSuggestions(String word, List<String> suggestions, int count) {
-            if(isWord) {
+            if (isWord) {
                 suggestions.add(word);
             }
-            if(suggestions.size() >= count) {
+            if (suggestions.size() >= count) {
                 return;
             }
             children.forEach((character, childNode) -> {
@@ -53,7 +48,7 @@ public class Trie {
     private static final int MAX_PREFIX_LENGTH = 30;
     public static final int ZERO = 0;
 
-    private final Node root = new Node(' ');
+    private final Node root = new Node();
 
     public void insert(String word) {
         if (word.length() > MAX_WORD_LENGTH) {

--- a/src/main/java/com/seong/shoutlink/domain/common/Trie.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/Trie.java
@@ -3,8 +3,8 @@ package com.seong.shoutlink.domain.common;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Getter;
 
 @Getter
@@ -13,10 +13,10 @@ public class Trie {
     static class Node {
 
         private final Map<Character, Node> children = new ConcurrentHashMap<>();
-        private boolean isWord;
+        private final AtomicBoolean isWord = new AtomicBoolean(false);
 
         public void settingWord() {
-            isWord = true;
+            isWord.compareAndSet(false, true);
         }
 
         public boolean hasChildren(char c) {
@@ -24,13 +24,11 @@ public class Trie {
         }
 
         public Node nextNode(char c) {
-            Node nextNode = children.putIfAbsent(c, new Node());
-            return Optional.ofNullable(nextNode)
-                .orElseGet(() -> children.get(c));
+            return children.computeIfAbsent(c, key -> new Node());
         }
 
         public void addSuggestions(String word, List<String> suggestions, int count) {
-            if (isWord) {
+            if (isWord.get()) {
                 suggestions.add(word);
             }
             if (suggestions.size() >= count) {

--- a/src/test/java/com/seong/shoutlink/domain/common/TrieTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/common/TrieTest.java
@@ -15,6 +15,17 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 class TrieTest {
 
+    private final String[] words = {
+        "apple", "ant", "arm", "anchor", "angle",
+        "alphabet", "album", "alien", "apron", "atom",
+        "axe", "art", "architect", "area", "arena",
+        "altitude", "almond", "aroma", "arrow", "ash",
+        "auction", "audio", "attic", "author", "award",
+        "charge", "crown", "cross", "cup", "cap",
+        "crop", "card", "chip", "case", "camp",
+        "club", "court", "crash", "class", "corner"
+    };
+
     @Nested
     @DisplayName("insert 호출 시")
     class InsertTest {
@@ -58,8 +69,8 @@ class TrieTest {
         void concurrentInsert() throws InterruptedException {
             //given
             Trie trie = new Trie();
-            String prefix = "asdf";
-            int threadPoolSize = 26;
+            String prefix = "";
+            int threadPoolSize = words.length;
             ExecutorService service = Executors.newFixedThreadPool(threadPoolSize);
             CountDownLatch latch = new CountDownLatch(threadPoolSize);
 
@@ -68,9 +79,7 @@ class TrieTest {
                 int finalI = i;
                 service.submit(() -> {
                     try {
-                        StringBuilder sb = new StringBuilder(prefix);
-                        sb.append((char) ('a' + finalI));
-                        trie.insert(sb.toString());
+                        trie.insert(words[finalI]);
                     } finally {
                         latch.countDown();
                     }


### PR DESCRIPTION
## 작업 내용

- TrieNode의 isWord를 기본형인 boolean에서 AtomicBoolean으로 변경했습니다.
- TrieNode에서 스스로의 문자를 나타내던 필드가 사용되는 곳이 없어 제거했습니다.
- TireNode의 nextNode()의 연산이 원자적으로 이루어지도록 수정했습니다.
- Trie의 테스트 코드를 수정했습니다. 더하기 연산으로 입력할 문자열을 만들어내던 것에서 미리 선언한 문자열 배열을 이용하도록 변경했습니다.