### PR TITLE
Refactor: @Entity 클래스의 간접 참조를 직접 참조로 변경한다. 

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/hub/repository/HubMemberEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/hub/repository/HubMemberEntity.java
@@ -2,6 +2,7 @@ package com.seong.shoutlink.domain.hub.repository;
 
 import com.seong.shoutlink.domain.common.BaseEntity;
 import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -27,33 +28,34 @@ public class HubMemberEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long hubMemberId;
 
-    @Column(nullable = false)
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private MemberEntity member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hub_id", nullable = false, updatable = false)
-    private HubEntity hubEntity;
+    private HubEntity hub;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private HubMemberRole hubMemberRole;
 
-    public HubMemberEntity(Long memberId, HubEntity hubEntity, HubMemberRole hubMemberRole) {
-        this.memberId = memberId;
-        this.hubEntity = hubEntity;
+    public HubMemberEntity(MemberEntity memberEntity, HubEntity hubEntity, HubMemberRole hubMemberRole) {
+        this.member = memberEntity;
+        this.hub = hubEntity;
         this.hubMemberRole = hubMemberRole;
     }
 
-    public static HubMemberEntity create(HubEntity hubEntity, Long masterId) {
-        return new HubMemberEntity(masterId, hubEntity, HubMemberRole.MASTER);
+    public static HubMemberEntity create(MemberEntity memberEntity, HubEntity hubEntity) {
+        return new HubMemberEntity(memberEntity, hubEntity, HubMemberRole.MASTER);
     }
 
     public Hub toHub() {
         return new Hub(
-            hubEntity.getHubId(),
-            memberId,
-            hubEntity.getName(),
-            hubEntity.getDescription(),
-            hubEntity.isPrivate());
+            hub.getHubId(),
+            member.getMemberId(),
+            hub.getName(),
+            hub.getDescription(),
+            hub.isPrivate());
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/hub/repository/HubMemberJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/hub/repository/HubMemberJpaRepository.java
@@ -31,7 +31,7 @@ public interface HubMemberJpaRepository extends JpaRepository<HubMemberEntity, L
     Page<HubMemberEntity> findMemberHubs(@Param("memberId") Long memberId, PageRequest pageRequest);
 
     @Query("select hm from HubTagEntity t "
-        + "join HubMemberEntity hm on hm.hub.hubId = t.hubId "
+        + "join HubMemberEntity hm on hm.hub = t.hub "
         + "join fetch hm.hub h "
         + "join fetch hm.member m "
         + "where t.tagId in :tagIds "

--- a/src/main/java/com/seong/shoutlink/domain/hub/repository/HubMemberJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/hub/repository/HubMemberJpaRepository.java
@@ -11,25 +11,29 @@ import org.springframework.data.repository.query.Param;
 public interface HubMemberJpaRepository extends JpaRepository<HubMemberEntity, Long> {
 
     @Query("select hm from HubMemberEntity hm "
-        + "join hm.hubEntity h "
+        + "join fetch hm.hub h "
+        + "join fetch hm.member m "
         + "where h.hubId = :hubId "
         + "and hm.hubMemberRole = com.seong.shoutlink.domain.hub.repository.HubMemberRole.MASTER")
     Optional<HubMemberEntity> findHubWithMaster(@Param("hubId") Long hubId);
 
     @Query("select hm from HubMemberEntity hm "
-        + "join fetch hm.hubEntity h "
+        + "join fetch hm.hub h "
+        + "join fetch hm.member m "
         + "where hm.hubMemberRole = com.seong.shoutlink.domain.hub.repository.HubMemberRole.MASTER")
     Page<HubMemberEntity> findHubs(PageRequest pageRequest);
 
     @Query("select hm from HubMemberEntity hm "
-        + "join fetch hm.hubEntity h "
-        + "where hm.memberId=:memberId "
+        + "join fetch hm.hub h "
+        + "join fetch hm.member m "
+        + "where hm.member.memberId=:memberId "
         + "and hm.hubMemberRole = com.seong.shoutlink.domain.hub.repository.HubMemberRole.MASTER")
     Page<HubMemberEntity> findMemberHubs(@Param("memberId") Long memberId, PageRequest pageRequest);
 
     @Query("select hm from HubTagEntity t "
-        + "join HubMemberEntity hm on hm.hubEntity.hubId = t.hubId "
-        + "join fetch hm.hubEntity "
+        + "join HubMemberEntity hm on hm.hub.hubId = t.hubId "
+        + "join fetch hm.hub h "
+        + "join fetch hm.member m "
         + "where t.tagId in :tagIds "
         + "and hm.hubMemberRole = com.seong.shoutlink.domain.hub.repository.HubMemberRole.MASTER")
     Page<HubMemberEntity> findHubsContainsTagIds(@Param("tagIds") List<Long> tagIds, PageRequest pageRequest);

--- a/src/main/java/com/seong/shoutlink/domain/hub/repository/HubRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/hub/repository/HubRepositoryImpl.java
@@ -6,14 +6,15 @@ import com.seong.shoutlink.domain.hub.service.HubRepository;
 import com.seong.shoutlink.domain.hub.service.result.HubPaginationResult;
 import com.seong.shoutlink.domain.hub.service.result.TagResult;
 import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import com.seong.shoutlink.domain.member.repository.MemberJpaRepository;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,12 +25,11 @@ public class HubRepositoryImpl implements HubRepository {
     private final HubMemberJpaRepository hubMemberJpaRepository;
 
     @Override
-    @Transactional
     public Long save(Hub hub) {
-        HubEntity hubEntity = HubEntity.create(hub);
-        hubJpaRepository.save(hubEntity);
-        HubMemberEntity hubMemberEntity
-            = HubMemberEntity.create(hubEntity, hub.getMasterId());
+        MemberEntity memberEntity = memberJpaRepository.findById(hub.getMasterId())
+            .orElseThrow(NoSuchElementException::new);
+        HubEntity hubEntity = hubJpaRepository.save(HubEntity.create(hub));
+        HubMemberEntity hubMemberEntity = HubMemberEntity.create(memberEntity, hubEntity);
         hubMemberJpaRepository.save(hubMemberEntity);
         return hubEntity.getHubId();
     }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/HubLinkBundleEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/HubLinkBundleEntity.java
@@ -1,7 +1,11 @@
 package com.seong.shoutlink.domain.link.repository;
 
+import com.seong.shoutlink.domain.hub.repository.HubEntity;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,10 +18,12 @@ import lombok.NoArgsConstructor;
 @Table(name = "hub_link_bundle")
 public class HubLinkBundleEntity extends LinkBundleEntity {
 
-    private Long hubId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hub_id")
+    private HubEntity hub;
 
-    public HubLinkBundleEntity(String description, boolean isDefault, Long hubId) {
+    public HubLinkBundleEntity(String description, boolean isDefault, HubEntity hubEntity) {
         super(description, isDefault);
-        this.hubId = hubId;
+        this.hub = hubEntity;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkBundleEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkBundleEntity.java
@@ -1,11 +1,9 @@
 package com.seong.shoutlink.domain.link.repository;
 
 import com.seong.shoutlink.domain.common.BaseEntity;
-import com.seong.shoutlink.domain.hub.Hub;
-import com.seong.shoutlink.domain.link.HubLinkBundle;
+import com.seong.shoutlink.domain.hub.repository.HubEntity;
 import com.seong.shoutlink.domain.link.LinkBundle;
-import com.seong.shoutlink.domain.link.MemberLinkBundle;
-import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -40,23 +38,19 @@ public abstract class LinkBundleEntity extends BaseEntity {
         this.isDefault = isDefault;
     }
 
-    public static LinkBundleEntity create(MemberLinkBundle memberLinkBundle) {
-        LinkBundle linkBundle = memberLinkBundle.getLinkBundle();
-        Member member = memberLinkBundle.getMember();
+    public static LinkBundleEntity create(LinkBundle linkBundle, MemberEntity memberEntity) {
         return new MemberLinkBundleEntity(
             linkBundle.getDescription(),
             linkBundle.isDefault(),
-            member.getMemberId()
+            memberEntity
         );
     }
 
-    public static LinkBundleEntity create(HubLinkBundle hubLinkBundle) {
-        LinkBundle linkBundle = hubLinkBundle.getLinkBundle();
-        Hub hub = hubLinkBundle.getHub();
+    public static LinkBundleEntity create(LinkBundle linkBundle, HubEntity hubEntity) {
         return new HubLinkBundleEntity(
             linkBundle.getDescription(),
             linkBundle.isDefault(),
-            hub.getHubId()
+            hubEntity
         );
     }
 

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkBundleJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkBundleJpaRepository.java
@@ -11,25 +11,25 @@ public interface LinkBundleJpaRepository extends JpaRepository<LinkBundleEntity,
 
     @Modifying
     @Query("update MemberLinkBundleEntity lb set lb.isDefault = false"
-        + " where lb.isDefault = true and lb.memberId = :memberId")
+        + " where lb.isDefault = true and lb.member.memberId = :memberId")
     void updateDefaultBundleFalse(@Param("memberId") Long memberId);
 
     @Query("select lb from MemberLinkBundleEntity lb "
-        + "where lb.memberId = :memberId")
+        + "where lb.member.memberId = :memberId")
     List<LinkBundleEntity> findAllByMemberId(@Param("memberId") Long memberId);
 
     @Query("select lb from HubLinkBundleEntity lb "
-        + "where lb.linkBundleId = :linkBundleId and lb.hubId = :hubId")
+        + "where lb.linkBundleId = :linkBundleId and lb.hub.hubId = :hubId")
     Optional<LinkBundleEntity> findHubLinkBundle(
         @Param("linkBundleId") Long linkBundleId,
         @Param("hubId") Long hubId);
 
     @Query("select lb from HubLinkBundleEntity lb "
-        + "where lb.hubId = :hubId")
+        + "where lb.hub.hubId = :hubId")
     List<LinkBundleEntity> findAllByHubId(@Param("hubId") Long hubId);
 
     @Query("select lb from MemberLinkBundleEntity lb "
-        + "where lb.linkBundleId = :linkBundleId and lb.memberId = :memberId")
+        + "where lb.linkBundleId = :linkBundleId and lb.member.memberId = :memberId")
     Optional<LinkBundleEntity> findMemberLinkBundle(
         @Param("linkBundleId") Long linkBundleId,
         @Param("memberId") Long memberId);

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkBundleRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkBundleRepositoryImpl.java
@@ -1,12 +1,17 @@
 package com.seong.shoutlink.domain.link.repository;
 
 import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.hub.repository.HubEntity;
+import com.seong.shoutlink.domain.hub.repository.HubJpaRepository;
 import com.seong.shoutlink.domain.link.HubLinkBundle;
 import com.seong.shoutlink.domain.link.LinkBundle;
 import com.seong.shoutlink.domain.link.MemberLinkBundle;
 import com.seong.shoutlink.domain.link.service.LinkBundleRepository;
 import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
+import com.seong.shoutlink.domain.member.repository.MemberJpaRepository;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,10 +21,16 @@ import org.springframework.stereotype.Repository;
 public class LinkBundleRepositoryImpl implements LinkBundleRepository {
 
     private final LinkBundleJpaRepository linkBundleJpaRepository;
+    private final MemberJpaRepository memberJpaRepository;
+    private final HubJpaRepository hubJpaRepository;
 
     @Override
     public Long save(MemberLinkBundle memberLinkBundle) {
-        LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(memberLinkBundle);
+        Member member = memberLinkBundle.getMember();
+        LinkBundle linkBundle = memberLinkBundle.getLinkBundle();
+        MemberEntity memberEntity = memberJpaRepository.findById(member.getMemberId())
+            .orElseThrow(NoSuchElementException::new);
+        LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(linkBundle, memberEntity);
         linkBundleJpaRepository.save(linkBundleEntity);
         return linkBundleEntity.getLinkBundleId();
     }
@@ -44,7 +55,11 @@ public class LinkBundleRepositoryImpl implements LinkBundleRepository {
 
     @Override
     public Long save(HubLinkBundle hubLinkBundle) {
-        LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(hubLinkBundle);
+        LinkBundle linkBundle = hubLinkBundle.getLinkBundle();
+        Hub hub = hubLinkBundle.getHub();
+        HubEntity hubEntity = hubJpaRepository.findById(hub.getHubId())
+            .orElseThrow(NoSuchElementException::new);
+        LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(linkBundle, hubEntity);
         linkBundleJpaRepository.save(linkBundleEntity);
         return linkBundleEntity.getLinkBundleId();
     }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkEntity.java
@@ -3,12 +3,14 @@ package com.seong.shoutlink.domain.link.repository;
 import com.seong.shoutlink.domain.common.BaseEntity;
 import com.seong.shoutlink.domain.domain.Domain;
 import com.seong.shoutlink.domain.link.Link;
-import com.seong.shoutlink.domain.link.LinkBundleAndLink;
-import com.seong.shoutlink.domain.link.LinkBundle;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,24 +26,29 @@ public class LinkEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long linkId;
 
+    @Column(nullable = false)
     private String url;
+
+    @Column
     private String description;
-    private Long linkBundleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "link_bundle_id", nullable = false)
+    private LinkBundleEntity linkBundle;
+
     private Long domainId;
 
-    private LinkEntity(String url, String description, Long linkBundleId) {
+    private LinkEntity(String url, String description, LinkBundleEntity linkBundleEntity) {
         this.url = url;
         this.description = description;
-        this.linkBundleId = linkBundleId;
+        this.linkBundle = linkBundleEntity;
     }
 
-    public static LinkEntity create(LinkBundleAndLink linkBundleAndLink) {
-        Link link = linkBundleAndLink.getLink();
-        LinkBundle linkBundle = linkBundleAndLink.getLinkBundle();
+    public static LinkEntity create(Link link, LinkBundleEntity linkBundleEntity) {
         return new LinkEntity(
             link.getUrl(),
             link.getDescription(),
-            linkBundle.getLinkBundleId());
+            linkBundleEntity);
     }
 
     public Link toDomain() {
@@ -52,7 +59,7 @@ public class LinkEntity extends BaseEntity {
         domainId = domain.getDomainId();
     }
 
-    public boolean isContainsIn(LinkBundle linkBundle) {
-        return linkBundleId.equals(linkBundle.getLinkBundleId());
+    public Long getLinkBundleId() {
+        return linkBundle.getLinkBundleId();
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
@@ -20,15 +20,15 @@ public interface LinkJpaRepository extends JpaRepository<LinkEntity, Long> {
         + " order by count(l.url) desc")
     Page<DomainLinkResult> findDomainLinks(@Param("domainId") Long domainId, Pageable pageable);
 
-    List<LinkEntity> findAllByLinkBundleIdIn(List<Long> linkBundleIds);
+    List<LinkEntity> findAllByLinkBundleLinkBundleIdIn(List<Long> linkBundleIds);
 
     @Query("select l from LinkEntity l "
-        + "join MemberLinkBundleEntity lb on l.linkBundleId = lb.linkBundleId "
+        + "join fetch MemberLinkBundleEntity lb "
         + "where l.linkId = :linkId and lb.member.memberId = :memberId")
     Optional<LinkEntity> findByIdAndMemberId(@Param("linkId") Long linkId, @Param("memberId") Long memberId);
 
     @Query("select l from LinkEntity l "
-        + "join HubLinkBundleEntity lb on l.linkBundleId = lb.linkBundleId "
+        + "join fetch HubLinkBundleEntity lb "
         + "where l.linkId = :linkId and lb.hub.hubId = :hubId")
     Optional<LinkEntity> findByIdAndHubId(@Param("linkId") Long linkId, @Param("hubId") Long hubId);
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkJpaRepository.java
@@ -24,11 +24,11 @@ public interface LinkJpaRepository extends JpaRepository<LinkEntity, Long> {
 
     @Query("select l from LinkEntity l "
         + "join MemberLinkBundleEntity lb on l.linkBundleId = lb.linkBundleId "
-        + "where l.linkId = :linkId and lb.memberId = :memberId")
+        + "where l.linkId = :linkId and lb.member.memberId = :memberId")
     Optional<LinkEntity> findByIdAndMemberId(@Param("linkId") Long linkId, @Param("memberId") Long memberId);
 
     @Query("select l from LinkEntity l "
         + "join HubLinkBundleEntity lb on l.linkBundleId = lb.linkBundleId "
-        + "where l.linkId = :linkId and lb.hubId = :hubId")
+        + "where l.linkId = :linkId and lb.hub.hubId = :hubId")
     Optional<LinkEntity> findByIdAndHubId(@Param("linkId") Long linkId, @Param("hubId") Long hubId);
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/LinkRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.seong.shoutlink.domain.link.LinkBundle;
 import com.seong.shoutlink.domain.member.Member;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +22,17 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class LinkRepositoryImpl implements LinkRepository {
 
+    private final LinkBundleJpaRepository linkBundleJpaRepository;
     private final LinkJpaRepository linkJpaRepository;
 
     @Override
     public Long save(LinkBundleAndLink linkBundleAndLink) {
-        LinkEntity linkEntity = linkJpaRepository.save(LinkEntity.create(linkBundleAndLink));
+        Link link = linkBundleAndLink.getLink();
+        LinkBundle linkBundle = linkBundleAndLink.getLinkBundle();
+        LinkBundleEntity linkBundleEntity = linkBundleJpaRepository.findById(
+                linkBundle.getLinkBundleId())
+            .orElseThrow(NoSuchElementException::new);
+        LinkEntity linkEntity = linkJpaRepository.save(LinkEntity.create(link, linkBundleEntity));
         return linkEntity.getLinkId();
     }
 
@@ -62,7 +69,7 @@ public class LinkRepositoryImpl implements LinkRepository {
         List<Long> linkBundleIds = linkBundles.stream()
             .map(LinkBundle::getLinkBundleId)
             .toList();
-        List<LinkEntity> linkEntities = linkJpaRepository.findAllByLinkBundleIdIn(linkBundleIds);
+        List<LinkEntity> linkEntities = linkJpaRepository.findAllByLinkBundleLinkBundleIdIn(linkBundleIds);
         Map<Long, LinkBundle> linkBundleIdAndLinkBundle = linkBundles.stream()
             .collect(Collectors.toMap(LinkBundle::getLinkBundleId, linkBundle -> linkBundle));
         return linkEntities.stream()

--- a/src/main/java/com/seong/shoutlink/domain/link/repository/MemberLinkBundleEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/repository/MemberLinkBundleEntity.java
@@ -1,7 +1,11 @@
 package com.seong.shoutlink.domain.link.repository;
 
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,10 +18,12 @@ import lombok.NoArgsConstructor;
 @Table(name = "member_link_bundle")
 public class MemberLinkBundleEntity extends LinkBundleEntity {
 
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
 
-    public MemberLinkBundleEntity(String description, boolean isDefault, Long memberId) {
+    public MemberLinkBundleEntity(String description, boolean isDefault, MemberEntity memberEntity) {
         super(description, isDefault);
-        this.memberId = memberId;
+        this.member = memberEntity;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/HubTag.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/HubTag.java
@@ -13,4 +13,8 @@ public class HubTag {
         this.hub = hub;
         this.tag = tag;
     }
+
+    public Long getHubId() {
+        return hub.getHubId();
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/MemberTag.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/MemberTag.java
@@ -13,4 +13,8 @@ public class MemberTag {
         this.member = member;
         this.tag = tag;
     }
+
+    public Long getMemberId() {
+        return member.getMemberId();
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/HubTagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/HubTagEntity.java
@@ -1,7 +1,11 @@
 package com.seong.shoutlink.domain.tag.repository;
 
+import com.seong.shoutlink.domain.hub.repository.HubEntity;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +16,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HubTagEntity extends TagEntity {
 
-    private Long hubId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hub_id")
+    private HubEntity hub;
 
-    public HubTagEntity(String name, Long hubId) {
+    public HubTagEntity(String name, HubEntity hubEntity) {
         super(name);
-        this.hubId = hubId;
+        this.hub = hubEntity;
+    }
+
+    public Long getHubId() {
+        return hub.getHubId();
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/MemberTagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/MemberTagEntity.java
@@ -1,7 +1,11 @@
 package com.seong.shoutlink.domain.tag.repository;
 
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +16,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberTagEntity extends TagEntity {
 
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
 
-    public MemberTagEntity(String name, Long memberId) {
+    public MemberTagEntity(String name, MemberEntity memberEntity) {
         super(name);
-        this.memberId = memberId;
+        this.member = memberEntity;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagEntity.java
@@ -1,10 +1,8 @@
 package com.seong.shoutlink.domain.tag.repository;
 
 import com.seong.shoutlink.domain.common.BaseEntity;
-import com.seong.shoutlink.domain.hub.Hub;
-import com.seong.shoutlink.domain.member.Member;
-import com.seong.shoutlink.domain.tag.HubTag;
-import com.seong.shoutlink.domain.tag.MemberTag;
+import com.seong.shoutlink.domain.hub.repository.HubEntity;
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import com.seong.shoutlink.domain.tag.Tag;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
@@ -36,16 +34,12 @@ public abstract class TagEntity extends BaseEntity {
         this.name = name;
     }
 
-    public static TagEntity from(HubTag hubTag) {
-        Hub hub = hubTag.getHub();
-        Tag tag = hubTag.getTag();
-        return new HubTagEntity(tag.getName(), hub.getHubId());
+    public static TagEntity create(Tag tag, HubEntity hubEntity) {
+        return new HubTagEntity(tag.getName(), hubEntity);
     }
 
-    public static TagEntity from(MemberTag memberTag) {
-        Member member = memberTag.getMember();
-        Tag tag = memberTag.getTag();
-        return new MemberTagEntity(tag.getName(), member.getMemberId());
+    public static TagEntity create(Tag tag, MemberEntity memberEntity) {
+        return new MemberTagEntity(tag.getName(), memberEntity);
     }
 
     public Tag toDomain() {

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagJpaRepository.java
@@ -10,25 +10,25 @@ import org.springframework.data.repository.query.Param;
 public interface TagJpaRepository extends JpaRepository<TagEntity, Long> {
 
     @Modifying
-    @Query("delete from HubTagEntity t where t.hubId=:hubId")
+    @Query("delete from HubTagEntity t where t.hub.hubId=:hubId")
     void deleteByHubId(@Param("hubId") Long hubId);
 
     @Query("select t from HubTagEntity t"
-        + " where t.hubId=:hubId"
+        + " where t.hub.hubId=:hubId"
         + " order by t.createdAt"
         + " limit 1")
     Optional<TagEntity> findLatestTagByHubId(Long hubId);
 
     @Query("select t from HubTagEntity t"
-        + " where t.hubId in :hubIds")
+        + " where t.hub.hubId in :hubIds")
     List<HubTagEntity> findTagsInHubIds(@Param("hubIds") List<Long> hubIds);
 
     @Modifying
-    @Query("delete from MemberTagEntity t where t.memberId=:memberId")
+    @Query("delete from MemberTagEntity t where t.member.memberId=:memberId")
     void deleteByMemberId(Long memberId);
 
     @Query("select t from MemberTagEntity t"
-        + " where t.memberId=:memberId"
+        + " where t.member.memberId=:memberId"
         + " order by t.createdAt"
         + " limit 1")
     Optional<TagEntity> findLatestTagByMemberId(Long memberId);

--- a/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/repository/TagRepositoryImpl.java
@@ -1,10 +1,14 @@
 package com.seong.shoutlink.domain.tag.repository;
 
 import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.hub.repository.HubEntity;
+import com.seong.shoutlink.domain.hub.repository.HubJpaRepository;
 import com.seong.shoutlink.domain.hub.service.HubTagReader;
 import com.seong.shoutlink.domain.hub.service.result.HubTagResult;
 import com.seong.shoutlink.domain.hub.service.result.TagResult;
 import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
+import com.seong.shoutlink.domain.member.repository.MemberJpaRepository;
 import com.seong.shoutlink.domain.tag.HubTag;
 import com.seong.shoutlink.domain.tag.MemberTag;
 import com.seong.shoutlink.domain.tag.Tag;
@@ -21,11 +25,23 @@ import org.springframework.stereotype.Repository;
 public class TagRepositoryImpl implements TagRepository, HubTagReader {
 
     private final TagJpaRepository tagJpaRepository;
+    private final HubJpaRepository hubJpaRepository;
+    private final MemberJpaRepository memberJpaRepository;
 
     @Override
     public List<Tag> saveHubTags(List<HubTag> tags) {
+        List<Long> hubIds = tags.stream()
+            .map(HubTag::getHubId)
+            .toList();
+        Map<Long, HubEntity> hubEntityCollectById = hubJpaRepository.findAllById(hubIds)
+            .stream()
+            .collect(Collectors.toMap(HubEntity::getHubId, hubEntity -> hubEntity));
         List<TagEntity> tagEntities = tags.stream()
-            .map(TagEntity::from)
+            .map(hubTag -> {
+                Tag tag = hubTag.getTag();
+                Hub hub = hubTag.getHub();
+                return TagEntity.create(tag, hubEntityCollectById.get(hub.getHubId()));
+            })
             .toList();
         return tagJpaRepository.saveAll(tagEntities).stream()
             .map(TagEntity::toDomain)
@@ -56,8 +72,18 @@ public class TagRepositoryImpl implements TagRepository, HubTagReader {
 
     @Override
     public List<Tag> saveMemberTags(List<MemberTag> memberTags) {
+        List<Long> memberIds = memberTags.stream()
+            .map(MemberTag::getMemberId)
+            .toList();
+        Map<Long, MemberEntity> memberEntityCollectById = memberJpaRepository.findAllById(memberIds)
+            .stream()
+            .collect(Collectors.toMap(MemberEntity::getMemberId, memberEntity -> memberEntity));
         List<TagEntity> tagEntities = memberTags.stream()
-            .map(TagEntity::from)
+            .map(memberTag -> {
+                Tag tag = memberTag.getTag();
+                Member member = memberTag.getMember();
+                return TagEntity.create(tag, memberEntityCollectById.get(member.getMemberId()));
+            })
             .toList();
         return tagJpaRepository.saveAll(tagEntities).stream()
             .map(TagEntity::toDomain)

--- a/src/test/java/com/seong/shoutlink/global/event/LinkBundleEventListenerTest.java
+++ b/src/test/java/com/seong/shoutlink/global/event/LinkBundleEventListenerTest.java
@@ -53,7 +53,7 @@ class LinkBundleEventListenerTest extends BaseIntegrationTest {
 
             //then
             LinkBundleEntity linkBundleEntity = em.createQuery(
-                    "select mlb from MemberLinkBundleEntity mlb where mlb.memberId = :memberId",
+                    "select mlb from MemberLinkBundleEntity mlb where mlb.member.memberId = :memberId",
                     LinkBundleEntity.class)
                 .setParameter("memberId", member.getMemberId())
                 .getSingleResult();
@@ -79,7 +79,7 @@ class LinkBundleEventListenerTest extends BaseIntegrationTest {
             //then
             LinkBundleEntity linkBundleEntity = em.createQuery(
                     "select hlb from HubLinkBundleEntity hlb "
-                        + "where hlb.hubId = :hubId", LinkBundleEntity.class)
+                        + "where hlb.hub.hubId = :hubId", LinkBundleEntity.class)
                 .setParameter("hubId", response.hubId())
                 .getSingleResult();
             assertThat(linkBundleEntity.getDescription()).isEqualTo("기본");


### PR DESCRIPTION
## 작업 내용

- HubMemberEntity의 hubId, memberId 필드를 HubEntity, MemberEntity 직접 참조로 변경
- LinkBundleEntity를 상속하는 MemberLinkBundleEntity, HubLinkBundleEntity 각각의 필드 memberId, hubId를 MemberEntity, HubEntity 직접 참조로 변경
- TagEntity를 상속하는 MemberTagEntity, HubTagEntity 각가의 필드 memberId, hubId를 MemberEntity, HubEntity 직접 참조로 변경
- LinkEntity의 linkBundleId 필드를 LinkBundleEntity 직접 참조로 변경

## 추가 작업 필요

- Link와 Domain은 하나의 도메인으로 묶는 것을 생각해야할 것 같습니다.
- 이에 대해 결정한 뒤 LinkEntity의 domainId를 직접 참조로 변경할지에 대해 결정합니다.