### PR TITLE
Refactor: Trie를 개선한다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/common/Trie.java
+++ b/src/main/java/com/seong/shoutlink/domain/common/Trie.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.Getter;
 
-@Getter
 public class Trie {
 
     static class Node {
@@ -23,20 +21,25 @@ public class Trie {
             return children.containsKey(c);
         }
 
-        public Node nextNode(char c) {
+        public Node getOrCreateNextNode(char c) {
             return children.computeIfAbsent(c, key -> new Node());
         }
 
-        public void addSuggestions(String word, List<String> suggestions, int count) {
+        public Node getNextNode(char c) {
+            return children.get(c);
+        }
+
+        public void addSuggestions(StringBuilder word, List<String> suggestions, int count) {
             if (isWord.get()) {
-                suggestions.add(word);
+                suggestions.add(word.toString());
             }
             if (suggestions.size() >= count) {
                 return;
             }
             children.forEach((character, childNode) -> {
-                String suggestionsWord = word + character;
-                childNode.addSuggestions(suggestionsWord, suggestions, count);
+                word.append(character);
+                childNode.addSuggestions(word, suggestions, count);
+                word.deleteCharAt(word.length() - 1);
             });
         }
     }
@@ -54,7 +57,7 @@ public class Trie {
         }
         Node currentNode = root;
         for (char c : word.toCharArray()) {
-            currentNode = currentNode.nextNode(c);
+            currentNode = currentNode.getOrCreateNextNode(c);
         }
         currentNode.settingWord();
     }
@@ -68,14 +71,14 @@ public class Trie {
             if (!currentNode.hasChildren(c)) {
                 return List.of();
             }
-            currentNode = currentNode.nextNode(c);
+            currentNode = currentNode.getNextNode(c);
         }
         return findWords(prefix, currentNode, Math.min(MAX_SUGGESTION, count));
     }
 
     private List<String> findWords(String word, Node currentNode, int count) {
         List<String> suggestions = new ArrayList<>();
-        currentNode.addSuggestions(word, suggestions, count);
+        currentNode.addSuggestions(new StringBuilder(word), suggestions, count);
         return suggestions;
     }
 }


### PR DESCRIPTION
## 작업 내용

- 불필요한 getter를 제거했습니다.
- prefix 검색 시 발생하는 문자열 더하기 연산을 StringBuilder를 사용하도록 변경하였습니다.
- insert와 search 메서드에서 다음 TrieNode를 찾기 위해 호출하는 TrieNode의 nextNode() 메서드를 분리했습니다.
  - insert는 기존 computeIfAbsent()를 사용하는 getOrCreateNextNode() 메서드를
  - search는 get()을 호출하는 getNextNode() 메서드를 사용합니다.