### PR TITLE
Refactor: 리포지토리 예외 핸들링을 추가한다. 

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/exception/ErrorCode.java
+++ b/src/main/java/com/seong/shoutlink/domain/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     NOT_FOUND("SL401", Constants.NOT_FOUND),
     DUPLICATE_EMAIL("SL901", Constants.CONFLICT),
     DUPLICATE_NICKNAME("SL902", Constants.BAD_REQUEST),
-    NOT_MET_CONDITION("SL1001", Constants.BAD_REQUEST);
+    NOT_MET_CONDITION("SL1001", Constants.BAD_REQUEST),
+    SERVER_ERROR("SL9999", Constants.SERVER_ERROR);
 
     private final String errorCode;
     private final int status;
@@ -26,5 +27,6 @@ public enum ErrorCode {
         private static final int FORBIDDEN = 401;
         private static final int NOT_FOUND = 404;
         private static final int CONFLICT = 409;
+        private static final int SERVER_ERROR = 500;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/exception/ErrorResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.seong.shoutlink.global.exception;
+package com.seong.shoutlink.domain.exception;
 
 public record ErrorResponse(String message, String errorCode) {
 

--- a/src/main/java/com/seong/shoutlink/domain/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seong/shoutlink/domain/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.seong.shoutlink.domain.exception;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -12,5 +15,12 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse
             = new ErrorResponse(e.getMessage(), e.getErrorCode().getErrorCode());
         return ResponseEntity.status(e.getErrorCode().getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> exHandle(Exception e) {
+        log.error("예측하지 못한 예외 발생, 메세지={}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(new ErrorResponse("서버 에러가 발생했습니다.", ErrorCode.SERVER_ERROR.getErrorCode()));
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seong/shoutlink/domain/exception/GlobalExceptionHandler.java
@@ -1,12 +1,11 @@
-package com.seong.shoutlink.global.exception;
+package com.seong.shoutlink.domain.exception;
 
-import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class globalExceptionHandler {
+public class GlobalExceptionHandler {
 
     @ExceptionHandler(ShoutLinkException.class)
     public ResponseEntity<ErrorResponse> shoutLinkExHandle(ShoutLinkException e) {

--- a/src/main/java/com/seong/shoutlink/domain/hub/repository/HubRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/hub/repository/HubRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import com.seong.shoutlink.domain.member.repository.MemberJpaRepository;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,7 +26,7 @@ public class HubRepositoryImpl implements HubRepository {
     @Override
     public Long save(Hub hub) {
         MemberEntity memberEntity = memberJpaRepository.findById(hub.getMasterId())
-            .orElseThrow(NoSuchElementException::new);
+            .orElseThrow(IllegalStateException::new);
         HubEntity hubEntity = hubJpaRepository.save(HubEntity.create(hub));
         HubMemberEntity hubMemberEntity = HubMemberEntity.create(memberEntity, hubEntity);
         hubMemberJpaRepository.save(hubMemberEntity);

--- a/src/main/java/com/seong/shoutlink/domain/link/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/repository/LinkRepositoryImpl.java
@@ -1,14 +1,14 @@
 package com.seong.shoutlink.domain.link.link.repository;
 
-import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleEntity;
-import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleJpaRepository;
-import com.seong.shoutlink.domain.link.linkdomain.LinkDomain;
 import com.seong.shoutlink.domain.hub.Hub;
 import com.seong.shoutlink.domain.link.link.Link;
 import com.seong.shoutlink.domain.link.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.link.service.LinkRepository;
 import com.seong.shoutlink.domain.link.link.service.result.LinkPaginationResult;
 import com.seong.shoutlink.domain.link.linkbundle.LinkBundle;
+import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleEntity;
+import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleJpaRepository;
+import com.seong.shoutlink.domain.link.linkdomain.LinkDomain;
 import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainCacheRepository;
 import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainEntity;
 import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainJpaRepository;
@@ -16,7 +16,6 @@ import com.seong.shoutlink.domain.link.linkdomain.util.DomainExtractor;
 import com.seong.shoutlink.domain.member.Member;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +44,7 @@ public class LinkRepositoryImpl implements LinkRepository {
             });
         LinkBundleEntity linkBundleEntity = linkBundleJpaRepository.findById(
                 linkBundle.getLinkBundleId())
-            .orElseThrow(NoSuchElementException::new);
+            .orElseThrow(IllegalStateException::new);
 
         return linkJpaRepository.save(LinkEntity.create(link, linkBundleEntity, linkDomainEntity))
             .getLinkId();

--- a/src/main/java/com/seong/shoutlink/domain/link/linkbundle/repository/LinkBundleRepositoryImpl.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/linkbundle/repository/LinkBundleRepositoryImpl.java
@@ -11,7 +11,6 @@ import com.seong.shoutlink.domain.member.Member;
 import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import com.seong.shoutlink.domain.member.repository.MemberJpaRepository;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -29,7 +28,7 @@ public class LinkBundleRepositoryImpl implements LinkBundleRepository {
         Member member = memberLinkBundle.getMember();
         LinkBundle linkBundle = memberLinkBundle.getLinkBundle();
         MemberEntity memberEntity = memberJpaRepository.findById(member.getMemberId())
-            .orElseThrow(NoSuchElementException::new);
+            .orElseThrow(IllegalStateException::new);
         LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(linkBundle, memberEntity);
         linkBundleJpaRepository.save(linkBundleEntity);
         return linkBundleEntity.getLinkBundleId();
@@ -58,7 +57,7 @@ public class LinkBundleRepositoryImpl implements LinkBundleRepository {
         LinkBundle linkBundle = hubLinkBundle.getLinkBundle();
         Hub hub = hubLinkBundle.getHub();
         HubEntity hubEntity = hubJpaRepository.findById(hub.getHubId())
-            .orElseThrow(NoSuchElementException::new);
+            .orElseThrow(IllegalStateException::new);
         LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(linkBundle, hubEntity);
         linkBundleJpaRepository.save(linkBundleEntity);
         return linkBundleEntity.getLinkBundleId();

--- a/src/test/java/com/seong/shoutlink/base/BaseRepositoryTest.java
+++ b/src/test/java/com/seong/shoutlink/base/BaseRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.seong.shoutlink.base;
+
+import com.seong.shoutlink.base.BaseRepositoryTest.CacheConfig;
+import com.seong.shoutlink.base.BaseRepositoryTest.RepositoryConfig;
+import com.seong.shoutlink.domain.hub.repository.HubJpaRepository;
+import com.seong.shoutlink.domain.hub.repository.HubMemberJpaRepository;
+import com.seong.shoutlink.domain.hub.repository.HubRepositoryImpl;
+import com.seong.shoutlink.domain.hub.service.HubRepository;
+import com.seong.shoutlink.domain.link.link.repository.LinkJpaRepository;
+import com.seong.shoutlink.domain.link.link.repository.LinkRepositoryImpl;
+import com.seong.shoutlink.domain.link.link.service.LinkRepository;
+import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleJpaRepository;
+import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleRepositoryImpl;
+import com.seong.shoutlink.domain.link.linkbundle.service.LinkBundleRepository;
+import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainCacheRepository;
+import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainJpaRepository;
+import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainMemoryRepository;
+import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainRepositoryImpl;
+import com.seong.shoutlink.domain.link.linkdomain.service.LinkDomainRepository;
+import com.seong.shoutlink.domain.member.repository.MemberJpaRepository;
+import com.seong.shoutlink.domain.member.repository.MemberRepositoryImpl;
+import com.seong.shoutlink.domain.member.service.MemberRepository;
+import com.seong.shoutlink.domain.tag.repository.TagJpaRepository;
+import com.seong.shoutlink.domain.tag.repository.TagRepositoryImpl;
+import com.seong.shoutlink.domain.tag.service.TagRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({RepositoryConfig.class, CacheConfig.class, DatabaseCleaner.class})
+public abstract class BaseRepositoryTest {
+
+    @TestConfiguration
+    static class RepositoryConfig {
+
+        @Autowired
+        MemberJpaRepository memberJpaRepository;
+
+        @Autowired
+        HubJpaRepository hubJpaRepository;
+
+        @Autowired
+        HubMemberJpaRepository hubMemberJpaRepository;
+
+        @Autowired
+        LinkBundleJpaRepository linkBundleJpaRepository;
+
+        @Autowired
+        LinkJpaRepository linkJpaRepository;
+
+        @Autowired
+        LinkDomainJpaRepository linkDomainJpaRepository;
+
+        @Autowired
+        TagJpaRepository tagJpaRepository;
+
+        @Bean
+        public MemberRepository memberRepository() {
+            return new MemberRepositoryImpl(memberJpaRepository);
+        }
+
+        @Bean
+        public HubRepository hubRepository() {
+            return new HubRepositoryImpl(memberJpaRepository, hubJpaRepository,
+                hubMemberJpaRepository);
+        }
+
+        @Bean
+        public LinkRepository linkRepository(LinkDomainCacheRepository linkDomainCacheRepository) {
+            return new LinkRepositoryImpl(linkBundleJpaRepository, linkJpaRepository,
+                linkDomainJpaRepository, linkDomainCacheRepository);
+        }
+
+        @Bean
+        public LinkBundleRepository linkBundleRepository() {
+            return new LinkBundleRepositoryImpl(linkBundleJpaRepository, memberJpaRepository,
+                hubJpaRepository);
+        }
+
+        @Bean
+        public LinkDomainRepository linkDomainRepository(LinkDomainCacheRepository linkDomainCacheRepository) {
+            return new LinkDomainRepositoryImpl(linkDomainJpaRepository, linkDomainCacheRepository,
+                linkJpaRepository);
+        }
+
+        @Bean
+        public TagRepository tagRepository() {
+            return new TagRepositoryImpl(tagJpaRepository, hubJpaRepository, memberJpaRepository);
+        }
+    }
+
+    @TestConfiguration
+    static class CacheConfig {
+
+        @Bean
+        public LinkDomainCacheRepository linkDomainCacheRepository() {
+            return new LinkDomainMemoryRepository();
+        }
+    }
+
+    @Autowired
+    protected EntityManager em;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.clear();
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/hub/repository/HubRepositoryImplTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/hub/repository/HubRepositoryImplTest.java
@@ -1,0 +1,39 @@
+package com.seong.shoutlink.domain.hub.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.shoutlink.base.BaseRepositoryTest;
+import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.fixture.HubFixture;
+import com.seong.shoutlink.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class HubRepositoryImplTest extends BaseRepositoryTest {
+
+    @Autowired
+    HubRepositoryImpl hubRepository;
+
+    @Nested
+    @DisplayName("save 호출 시")
+    class Save {
+
+        @Test
+        @DisplayName("예외(illegalStateEx): 존재하지 않는 회원 조회 시")
+        void illegalStateEx_WhenTryToFindMember_DoseNotExist() {
+            //given
+            Member member = MemberFixture.member();
+            Hub hub = HubFixture.hub(member);
+
+            //when
+            Exception exception = catchException(() -> hubRepository.save(hub));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalStateException.class);
+        }
+    }
+}

--- a/src/test/java/com/seong/shoutlink/domain/link/link/repository/LinkRepositoryImplTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/link/repository/LinkRepositoryImplTest.java
@@ -2,7 +2,7 @@ package com.seong.shoutlink.domain.link.link.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.seong.shoutlink.base.BaseIntegrationTest;
+import com.seong.shoutlink.base.BaseRepositoryTest;
 import com.seong.shoutlink.domain.link.link.Link;
 import com.seong.shoutlink.domain.link.link.LinkBundleAndLink;
 import com.seong.shoutlink.domain.link.linkbundle.LinkBundle;
@@ -16,20 +16,16 @@ import com.seong.shoutlink.domain.member.repository.MemberEntity;
 import com.seong.shoutlink.fixture.LinkBundleFixture;
 import com.seong.shoutlink.fixture.LinkFixture;
 import com.seong.shoutlink.fixture.MemberFixture;
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class LinkRepositoryImplTest extends BaseIntegrationTest {
+class LinkRepositoryImplTest extends BaseRepositoryTest {
 
     @Autowired
     private LinkRepositoryImpl linkRepository;
-
-    @Autowired
-    private EntityManager em;
 
     @Autowired
     private LinkDomainCacheRepository linkDomainCacheRepository;
@@ -49,8 +45,8 @@ class LinkRepositoryImplTest extends BaseIntegrationTest {
             MemberEntity memberEntity = MemberEntity.create(member);
             LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(linkBundle, memberEntity);
 
-            persist(memberEntity);
-            persist(linkBundleEntity);
+            em.persist(memberEntity);
+            em.persist(linkBundleEntity);
 
             //when
             Long savedLinkId = linkRepository.save(linkBundleAndLink);
@@ -77,9 +73,9 @@ class LinkRepositoryImplTest extends BaseIntegrationTest {
             LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
                 new LinkDomain(DomainExtractor.extractRootDomain(link.getUrl())));
 
-            persist(memberEntity);
-            persist(linkBundleEntity);
-            persist(linkDomainEntity);
+            em.persist(memberEntity);
+            em.persist(linkBundleEntity);
+            em.persist(linkDomainEntity);
 
             //when
             Long linkId = linkRepository.save(linkBundleAndLink);
@@ -101,8 +97,8 @@ class LinkRepositoryImplTest extends BaseIntegrationTest {
             MemberEntity memberEntity = MemberEntity.create(member);
             LinkBundleEntity linkBundleEntity = LinkBundleEntity.create(linkBundle, memberEntity);
 
-            persist(memberEntity);
-            persist(linkBundleEntity);
+            em.persist(memberEntity);
+            em.persist(linkBundleEntity);
 
             //when
             Long savedLinkId = linkRepository.save(linkBundleAndLink);

--- a/src/test/java/com/seong/shoutlink/domain/link/link/repository/LinkRepositoryImplTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/link/repository/LinkRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package com.seong.shoutlink.domain.link.link.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.shoutlink.base.BaseRepositoryTest;
 import com.seong.shoutlink.domain.link.link.Link;
@@ -107,6 +108,21 @@ class LinkRepositoryImplTest extends BaseRepositoryTest {
             List<String> rootDomains = linkDomainCacheRepository.findRootDomains("", 10);
             assertThat(rootDomains).containsExactly(
                 DomainExtractor.extractRootDomain(link.getUrl()));
+        }
+
+        @Test
+        @DisplayName("예외(illegalStateEx): 존재하지 않는 링크 묶음 조회 시")
+        void illegalStateEx_WhenTryToFindLinkBundle_DoseNotExist() {
+            //given
+            LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+            Link link = LinkFixture.link();
+            LinkBundleAndLink linkBundleAndLink = new LinkBundleAndLink(link, linkBundle);
+
+            //when
+            Exception exception = catchException(() -> linkRepository.save(linkBundleAndLink));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalStateException.class);
         }
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/link/linkbundle/repository/LinkBundleRepositoryImplTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/linkbundle/repository/LinkBundleRepositoryImplTest.java
@@ -1,0 +1,72 @@
+package com.seong.shoutlink.domain.link.linkbundle.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.shoutlink.base.BaseRepositoryTest;
+import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.link.linkbundle.HubLinkBundle;
+import com.seong.shoutlink.domain.link.linkbundle.LinkBundle;
+import com.seong.shoutlink.domain.link.linkbundle.MemberLinkBundle;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.fixture.HubFixture;
+import com.seong.shoutlink.fixture.LinkBundleFixture;
+import com.seong.shoutlink.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class LinkBundleRepositoryImplTest extends BaseRepositoryTest {
+
+    @Autowired
+    LinkBundleRepositoryImpl linkBundleRepository;
+
+    @Nested
+    @DisplayName("save 호출 시")
+    class SaveTest {
+
+        @Nested
+        @DisplayName("MemberLinkBundle을 인수로 전달했을 때")
+        class Arg_MemberLinkBundle {
+
+            @Test
+            @DisplayName("예외(illegalStateEx): 존재하지 않는 회원 조회 시")
+            void illegalStateEx_WhenTryToFindMember_DoseNotExist() {
+                //given
+                Member member = MemberFixture.member();
+                LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+                MemberLinkBundle memberLinkBundle = new MemberLinkBundle(member, linkBundle);
+
+                //when
+                Exception exception = catchException(
+                    () -> linkBundleRepository.save(memberLinkBundle));
+
+                //then
+                assertThat(exception).isInstanceOf(IllegalStateException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("HubLinkBundle을 인수로 전달했을 때")
+        class Arg_HubLinkBundle {
+
+            @Test
+            @DisplayName("예외(illegalStateEx): 존재하지 않는 허브 조회 시")
+            void illegalStateEx_WhenTryToFindHub_DoseNotExist() {
+                //given
+                Member member = MemberFixture.member();
+                Hub hub = HubFixture.hub(member);
+                LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+                HubLinkBundle hubLinkBundle = new HubLinkBundle(hub, linkBundle);
+
+                //when
+                Exception exception = catchException(
+                    () -> linkBundleRepository.save(hubLinkBundle));
+
+                //then
+                assertThat(exception).isInstanceOf(IllegalStateException.class);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 영속성 계층에서 엔티티 존재하지 않는 엔티티 조회시 던지는 예외를 NoSuchElementException에서 IllegalStateException으로 변경했습니다.
  - 존재하지 않는 엔티티에 대해 새로운 엔티티를 저장하려는 행위까지 도달한 상황 자체를 잘못된 것으로 간주하는게 옳은듯하여 변경합니다.
- 해당 상황에 대한 테스트를 추가하면서 영속성 계층 통합 테스트를 위한 추상 클래스를 추가했습니다.
  - 해당 추상 클래스는 영속성 계층의 bean configuration을 통일하기 위해 사용합니다.
- Exception을 처리할 예외 핸들러를 추가했습니다.