### PR TITLE
Refactor: 외부 API 통신 예외를 추가한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/src/main/java/com/seong/shoutlink/global/client/api/ApiException.java
+++ b/src/main/java/com/seong/shoutlink/global/client/api/ApiException.java
@@ -1,0 +1,8 @@
+package com.seong.shoutlink.global.client.api;
+
+public class ApiException extends RuntimeException{
+
+    public ApiException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/seong/shoutlink/global/client/api/RestApiClientTest.java
+++ b/src/test/java/com/seong/shoutlink/global/client/api/RestApiClientTest.java
@@ -1,0 +1,115 @@
+package com.seong.shoutlink.global.client.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.shoutlink.base.BaseIntegrationTest;
+import java.io.IOException;
+import java.util.Map;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RestApiClientTest extends BaseIntegrationTest {
+
+    @Autowired
+    private RestApiClient restApiClient;
+
+    MockWebServer mockServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockServer.shutdown();
+    }
+
+    @Nested
+    @DisplayName("생성하면")
+    class CreateTest {
+
+        @Test
+        @DisplayName("예외(apiException): 5xx 에러일 때")
+        void whenStatusCode_5xx() {
+            //given
+            MockResponse mockResponse = new MockResponse()
+                .setResponseCode(500);
+            mockServer.enqueue(mockResponse);
+            HttpUrl baseUrl = mockServer.url("/server-error");
+
+            //when
+            Exception exception = catchException(
+                () -> restApiClient.post(baseUrl.toString(), Map.of(), Map.of(), ""));
+
+            //then
+            assertThat(exception).isInstanceOf(ApiException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("post 호출 시")
+    class WhenPost {
+
+        @Test
+        @DisplayName("성공")
+        void post() {
+            //given
+            MockResponse mockResponse = new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"content\": \"hello\"}");
+            mockServer.enqueue(mockResponse);
+            HttpUrl baseUrl = mockServer.url("/success");
+
+            //when
+            Map<String, Object> response = restApiClient.post(baseUrl.toString(), Map.of(),
+                Map.of(), "");
+
+            //then
+            assertThat(response.get("content")).isEqualTo("hello");
+        }
+
+        @Test
+        @DisplayName("예외(apiException): 4xx 에러일 때")
+        void whenStatusCode_4xx() {
+            //given
+            MockResponse mockResponse = new MockResponse()
+                .setResponseCode(400);
+            mockServer.enqueue(mockResponse);
+            HttpUrl baseUrl = mockServer.url("/client-error");
+
+            //when
+            Exception exception = catchException(
+                () -> restApiClient.post(baseUrl.toString(), Map.of(), Map.of(), ""));
+
+            //then
+            assertThat(exception).isInstanceOf(ApiException.class);
+        }
+
+        @Test
+        @DisplayName("예외(apiException): 응답 형식이 json이 아닐 때")
+        void whenResponse_isNotJson() {
+            //given
+            MockResponse mockResponse = new MockResponse()
+                .setBody("not json");
+            mockServer.enqueue(mockResponse);
+            HttpUrl baseUrl = mockServer.url("/not-json");
+
+            //when
+            Exception exception = catchException(
+                () -> restApiClient.post(baseUrl.toString(), Map.of(), Map.of(), ""));
+
+            //then
+            assertThat(exception).isInstanceOf(ApiException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- API 통신 시 발생하는 4xx, 5xx 에러에 대한 예외 처리를 추가하였습니다.
- API 통신 시 발생하는 에러에 대한 커스텀 예외를 추가하였습니다.
- 테스트를 위한 okhttp3 mockWebServer 의존성을 추가하였습니다.