### PR TITLE
Feat: 이벤트 리스너가 로직을 비동기 처리하도록 변경한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'org.awaitility:awaitility'
 
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.retry:spring-retry'
 
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/seong/shoutlink/domain/exception/AsyncExceptionHandler.java
+++ b/src/main/java/com/seong/shoutlink/domain/exception/AsyncExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.seong.shoutlink.domain.exception;
+
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.warn("비동기 처리 예외 발생. method={}, message={}, params={}", ex.getMessage(), method.getName(), params);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/link/link/service/event/CreateHubLinkEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/service/event/CreateHubLinkEvent.java
@@ -34,4 +34,11 @@ public class CreateHubLinkEvent extends CreateLinkEvent {
     public int hashCode() {
         return Objects.hash(super.hashCode(), hubId);
     }
+
+    @Override
+    public String toString() {
+        return "CreateHubLinkEvent{" +
+            "hubId=" + hubId +
+            '}';
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/link/service/event/CreateMemberLinkEvent.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/service/event/CreateMemberLinkEvent.java
@@ -34,4 +34,11 @@ public class CreateMemberLinkEvent extends CreateLinkEvent{
     public int hashCode() {
         return Objects.hash(super.hashCode(), memberId);
     }
+
+    @Override
+    public String toString() {
+        return "CreateMemberLinkEvent{" +
+            "memberId=" + memberId +
+            '}';
+    }
 }

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/NotMetCondition.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/NotMetCondition.java
@@ -1,0 +1,8 @@
+package com.seong.shoutlink.domain.tag.service;
+
+public class NotMetCondition extends RuntimeException{
+
+    public NotMetCondition(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
+++ b/src/main/java/com/seong/shoutlink/domain/tag/service/TagService.java
@@ -70,7 +70,8 @@ public class TagService implements TagUseCase {
         tagRepository.findLatestTagByHub(hub)
             .filter(Tag::isCreatedWithinADay)
             .ifPresent(tag -> {
-                throw new ShoutLinkException("태그 생성된 지 하루가 지나지 않았습니다.", ErrorCode.NOT_MET_CONDITION);});
+                throw new NotMetCondition("태그가 생성된 지 하루가 지나지 않았습니다.");
+            });
     }
 
     @Override
@@ -101,8 +102,7 @@ public class TagService implements TagUseCase {
         tagRepository.findLatestTagByMember(member)
             .filter(Tag::isCreatedWithinADay)
             .ifPresent(tag -> {
-                throw new ShoutLinkException("태그가 생성된 지 하루가 지나지 않았습니다.",
-                    ErrorCode.NOT_MET_CONDITION);
+                throw new NotMetCondition("태그가 생성된 지 하루가 지나지 않았습니다.");
             });
     }
 
@@ -120,7 +120,7 @@ public class TagService implements TagUseCase {
         int totalLinkCount = links.size();
         if (totalLinkCount < MINIMUM_TAG_CONDITION
             || totalLinkCount % MINIMUM_TAG_CONDITION != ZERO) {
-            throw new ShoutLinkException("태그 생성 조건을 충족하지 못했습니다.", ErrorCode.NOT_MET_CONDITION);
+            throw new NotMetCondition("태그 생성 조건을 충족하지 못했습니다.");
         }
         return Math.min(MAXIMUM_TAG_COUNT, totalLinkCount / MINIMUM_TAG_CONDITION);
     }

--- a/src/main/java/com/seong/shoutlink/global/config/AsyncConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/AsyncConfig.java
@@ -1,17 +1,20 @@
 package com.seong.shoutlink.global.config;
 
+import com.seong.shoutlink.domain.exception.AsyncExceptionHandler;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @EnableAsync
 @EnableRetry
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
     private static final int GENERATIVE_AI_CORE_POOL_SIZE = 3;
     private static final int GENERATIVE_AI_MAX_POOL_SIZE = 3;
@@ -46,5 +49,10 @@ public class AsyncConfig {
         executor.setThreadNamePrefix(DEFAULT_THREAD_NAME_PREFIX);
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
     }
 }

--- a/src/main/java/com/seong/shoutlink/global/config/AsyncConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/AsyncConfig.java
@@ -4,10 +4,12 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @EnableAsync
+@EnableRetry
 @Configuration
 public class AsyncConfig {
 

--- a/src/main/java/com/seong/shoutlink/global/config/AsyncConfig.java
+++ b/src/main/java/com/seong/shoutlink/global/config/AsyncConfig.java
@@ -1,0 +1,48 @@
+package com.seong.shoutlink.global.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    private static final int GENERATIVE_AI_CORE_POOL_SIZE = 3;
+    private static final int GENERATIVE_AI_MAX_POOL_SIZE = 3;
+    private static final String GENERATIVE_AI_THREAD_NAME_PREFIX = "GenerativeAITask-";
+    private static final int DEFAULT_CORE_POOL_SIZE = 10;
+    private static final int DEFAULT_MAX_POOL_SIZE = 10;
+    private static final String DEFAULT_THREAD_NAME_PREFIX = "DefaultTask-";
+    private static final int DEFAULT_QUEUE_CAPACITY = 50;
+    private static final boolean WAIT_TASK_COMPLETION = true;
+
+    @Bean(name = "generativeTaskExecutor")
+    public Executor generativeTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(GENERATIVE_AI_CORE_POOL_SIZE);
+        executor.setMaxPoolSize(GENERATIVE_AI_MAX_POOL_SIZE);
+        executor.setQueueCapacity(DEFAULT_QUEUE_CAPACITY);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(WAIT_TASK_COMPLETION);
+        executor.setThreadNamePrefix(GENERATIVE_AI_THREAD_NAME_PREFIX);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(DEFAULT_CORE_POOL_SIZE);
+        executor.setMaxPoolSize(DEFAULT_MAX_POOL_SIZE);
+        executor.setQueueCapacity(DEFAULT_QUEUE_CAPACITY);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(WAIT_TASK_COMPLETION);
+        executor.setThreadNamePrefix(DEFAULT_THREAD_NAME_PREFIX);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/seong/shoutlink/global/event/LinkBundleEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/LinkBundleEventListener.java
@@ -1,15 +1,17 @@
 package com.seong.shoutlink.global.event;
 
-import com.seong.shoutlink.domain.member.service.event.CreateMemberEvent;
 import com.seong.shoutlink.domain.hub.service.event.CreateHubEvent;
 import com.seong.shoutlink.domain.link.linkbundle.service.LinkBundleUseCase;
 import com.seong.shoutlink.domain.link.linkbundle.service.request.CreateHubLinkBundleCommand;
 import com.seong.shoutlink.domain.link.linkbundle.service.response.CreateLinkBundleCommand;
+import com.seong.shoutlink.domain.link.linkbundle.service.response.CreateLinkBundleResponse;
+import com.seong.shoutlink.domain.member.service.event.CreateMemberEvent;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @RequiredArgsConstructor
 public class LinkBundleEventListener {
 
@@ -17,22 +19,24 @@ public class LinkBundleEventListener {
 
     private final LinkBundleUseCase linkBundleUseCase;
 
+    @Async
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createDefaultLinkBundle(CreateMemberEvent event) {
         CreateLinkBundleCommand command
             = new CreateLinkBundleCommand(event.memberId(), DEFAULT_LINK_BUNDLE, true);
-        linkBundleUseCase.createLinkBundle(command);
+        CreateLinkBundleResponse response = linkBundleUseCase.createLinkBundle(command);
+        log.debug("[Event] 회원 기본 링크 번들 생성. linkBundleId={}", response.linkBundleId());
     }
 
+    @Async
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createDefaultHubLinkBundle(CreateHubEvent event) {
         CreateHubLinkBundleCommand command = new CreateHubLinkBundleCommand(
             event.hubId(),
             event.memberId(),
             DEFAULT_LINK_BUNDLE,
             true);
-        linkBundleUseCase.createHubLinkBundle(command);
+        CreateLinkBundleResponse response = linkBundleUseCase.createHubLinkBundle(command);
+        log.debug("[Event] 허브 기본 링크 번들 생성. linkBundleId={}", response.linkBundleId());
     }
 }

--- a/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
@@ -1,9 +1,8 @@
 package com.seong.shoutlink.global.event;
 
-import com.seong.shoutlink.domain.exception.ErrorCode;
-import com.seong.shoutlink.domain.exception.ShoutLinkException;
 import com.seong.shoutlink.domain.link.link.service.event.CreateHubLinkEvent;
 import com.seong.shoutlink.domain.link.link.service.event.CreateMemberLinkEvent;
+import com.seong.shoutlink.domain.tag.service.NotMetCondition;
 import com.seong.shoutlink.domain.tag.service.TagUseCase;
 import com.seong.shoutlink.domain.tag.service.request.AutoCreateHubTagCommand;
 import com.seong.shoutlink.domain.tag.service.request.AutoCreateMemberTagCommand;
@@ -26,12 +25,8 @@ public class TagEventListener {
         try {
             CreateTagResponse response = tagUseCase.autoCreateHubTags(command);
             log.debug("[Event] 허브 태그 자동 생성. tagIds={}", response.tagIds());
-        } catch (ShoutLinkException e) {
-            if(e.getErrorCode().equals(ErrorCode.NOT_MET_CONDITION)) {
-                log.debug("[Event] 회원 태그 자동 생성 취소. 조건을 만족하지 않음.");
-            } else {
-                throw e;
-            }
+        } catch (NotMetCondition e) {
+            log.debug("[Event] 허브 태그 자동 생성 취소. 조건을 만족하지 않음.");
         }
     }
 
@@ -42,12 +37,8 @@ public class TagEventListener {
         try {
             CreateTagResponse response = tagUseCase.autoCreateMemberTags(command);
             log.debug("[Event] 회원 태그 자동 생성. tagIds={}", response.tagIds());
-        } catch (ShoutLinkException e) {
-            if(e.getErrorCode().equals(ErrorCode.NOT_MET_CONDITION)) {
-                log.debug("[Event] 회원 태그 자동 생성 취소. 조건을 만족하지 않음.");
-            } else {
-                throw e;
-            }
+        } catch (NotMetCondition e) {
+            log.debug("[Event] 회원 태그 자동 생성 취소. 조건을 만족하지 않음.");
         }
     }
 }

--- a/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
@@ -7,10 +7,10 @@ import com.seong.shoutlink.domain.link.link.service.event.CreateMemberLinkEvent;
 import com.seong.shoutlink.domain.tag.service.TagUseCase;
 import com.seong.shoutlink.domain.tag.service.request.AutoCreateHubTagCommand;
 import com.seong.shoutlink.domain.tag.service.request.AutoCreateMemberTagCommand;
+import com.seong.shoutlink.domain.tag.service.response.CreateTagResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
@@ -19,32 +19,32 @@ public class TagEventListener {
 
     private final TagUseCase tagUseCase;
 
+    @Async(value = "generativeTaskExecutor")
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createHubTags(CreateHubLinkEvent event) {
         AutoCreateHubTagCommand command = new AutoCreateHubTagCommand(event.hubId());
         try {
-            tagUseCase.autoCreateHubTags(command);
-            log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족");
+            CreateTagResponse response = tagUseCase.autoCreateHubTags(command);
+            log.debug("[Event] 허브 태그 자동 생성. tagIds={}", response.tagIds());
         } catch (ShoutLinkException e) {
             if(e.getErrorCode().equals(ErrorCode.NOT_MET_CONDITION)) {
-                log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족하지 않음");
+                log.debug("[Event] 회원 태그 자동 생성 취소. 조건을 만족하지 않음.");
             } else {
                 throw e;
             }
         }
     }
 
+    @Async(value = "generativeTaskExecutor")
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createMemberTags(CreateMemberLinkEvent event) {
         AutoCreateMemberTagCommand command = new AutoCreateMemberTagCommand(event.memberId());
         try {
-            tagUseCase.autoCreateMemberTags(command);
-            log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족");
+            CreateTagResponse response = tagUseCase.autoCreateMemberTags(command);
+            log.debug("[Event] 회원 태그 자동 생성. tagIds={}", response.tagIds());
         } catch (ShoutLinkException e) {
             if(e.getErrorCode().equals(ErrorCode.NOT_MET_CONDITION)) {
-                log.debug("[Tag] 링크 개수가 최소 태그 자동 생성 조건을 만족하지 않음");
+                log.debug("[Event] 회원 태그 자동 생성 취소. 조건을 만족하지 않음.");
             } else {
                 throw e;
             }

--- a/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
+++ b/src/main/java/com/seong/shoutlink/global/event/TagEventListener.java
@@ -7,8 +7,12 @@ import com.seong.shoutlink.domain.tag.service.TagUseCase;
 import com.seong.shoutlink.domain.tag.service.request.AutoCreateHubTagCommand;
 import com.seong.shoutlink.domain.tag.service.request.AutoCreateMemberTagCommand;
 import com.seong.shoutlink.domain.tag.service.response.CreateTagResponse;
+import com.seong.shoutlink.global.client.api.ApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -18,6 +22,11 @@ public class TagEventListener {
 
     private final TagUseCase tagUseCase;
 
+    @Retryable(
+        retryFor = ApiException.class,
+        maxAttemptsExpression = "${retry.max-attempt}",
+        backoff = @Backoff(delayExpression = "${retry.delay}",
+            multiplierExpression = "${retry.multiply}"))
     @Async(value = "generativeTaskExecutor")
     @TransactionalEventListener
     public void createHubTags(CreateHubLinkEvent event) {
@@ -30,6 +39,11 @@ public class TagEventListener {
         }
     }
 
+    @Retryable(
+        retryFor = ApiException.class,
+        maxAttemptsExpression = "${retry.max-attempt}",
+        backoff = @Backoff(delayExpression = "${retry.delay}",
+            multiplierExpression = "${retry.multiply}"))
     @Async(value = "generativeTaskExecutor")
     @TransactionalEventListener
     public void createMemberTags(CreateMemberLinkEvent event) {
@@ -40,5 +54,11 @@ public class TagEventListener {
         } catch (NotMetCondition e) {
             log.debug("[Event] 회원 태그 자동 생성 취소. 조건을 만족하지 않음.");
         }
+    }
+
+    @Recover
+    public void recover(RuntimeException e) {
+        log.error("[Event] 태그 자동 생성 실패.", e);
+        throw e;
     }
 }

--- a/src/test/java/com/seong/shoutlink/base/BaseIntegrationTest.java
+++ b/src/test/java/com/seong/shoutlink/base/BaseIntegrationTest.java
@@ -21,11 +21,13 @@ public abstract class BaseIntegrationTest {
         databaseCleaner.clear();
     }
 
-    protected void persist(Object entity) {
+    protected void persist(Object... entity) {
         EntityManager em = emf.createEntityManager();
         EntityTransaction transaction = em.getTransaction();
         transaction.begin();
-        em.persist(entity);
+        for (Object o : entity) {
+            em.persist(o);
+        }
         transaction.commit();
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/tag/service/TagServiceTest.java
@@ -134,9 +134,7 @@ class TagServiceTest {
             Exception exception = catchException(() -> tagService.autoCreateHubTags(command));
 
             //then
-            assertThat(exception).isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+            assertThat(exception).isInstanceOf(NotMetCondition.class);
         }
 
         @ParameterizedTest
@@ -154,9 +152,7 @@ class TagServiceTest {
             Exception exception = catchException(() -> tagService.autoCreateHubTags(command));
 
             //then
-            assertThat(exception).isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+            assertThat(exception).isInstanceOf(NotMetCondition.class);
         }
 
         @ParameterizedTest
@@ -174,9 +170,7 @@ class TagServiceTest {
             Exception exception = catchException(() -> tagService.autoCreateHubTags(command));
 
             //then
-            assertThat(exception).isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+            assertThat(exception).isInstanceOf(NotMetCondition.class);
         }
     }
 
@@ -256,9 +250,7 @@ class TagServiceTest {
             Exception exception = catchException(() -> tagService.autoCreateMemberTags(command));
 
             //then
-            assertThat(exception).isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+            assertThat(exception).isInstanceOf(NotMetCondition.class);
         }
 
         @ParameterizedTest
@@ -276,9 +268,7 @@ class TagServiceTest {
             Exception exception = catchException(() -> tagService.autoCreateMemberTags(command));
 
             //then
-            assertThat(exception).isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+            assertThat(exception).isInstanceOf(NotMetCondition.class);
         }
 
         @ParameterizedTest
@@ -296,9 +286,7 @@ class TagServiceTest {
             Exception exception = catchException(() -> tagService.autoCreateMemberTags(command));
 
             //then
-            assertThat(exception).isInstanceOf(ShoutLinkException.class)
-                .extracting(e -> ((ShoutLinkException) e).getErrorCode())
-                .isEqualTo(ErrorCode.NOT_MET_CONDITION);
+            assertThat(exception).isInstanceOf(NotMetCondition.class);
         }
     }
 }

--- a/src/test/java/com/seong/shoutlink/global/event/LinkBundleEventListenerTest.java
+++ b/src/test/java/com/seong/shoutlink/global/event/LinkBundleEventListenerTest.java
@@ -13,6 +13,7 @@ import com.seong.shoutlink.domain.member.service.MemberService;
 import com.seong.shoutlink.domain.member.service.request.CreateMemberCommand;
 import com.seong.shoutlink.fixture.MemberFixture;
 import jakarta.persistence.EntityManager;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -52,12 +53,14 @@ class LinkBundleEventListenerTest extends BaseIntegrationTest {
             memberService.createMember(createMemberCommand);
 
             //then
-            LinkBundleEntity linkBundleEntity = em.createQuery(
-                    "select mlb from MemberLinkBundleEntity mlb where mlb.member.memberId = :memberId",
-                    LinkBundleEntity.class)
-                .setParameter("memberId", member.getMemberId())
-                .getSingleResult();
-            assertThat(linkBundleEntity.getDescription()).isEqualTo("기본");
+            Awaitility.await().untilAsserted(() -> {
+                LinkBundleEntity linkBundleEntity = em.createQuery(
+                        "select mlb from MemberLinkBundleEntity mlb where mlb.member.memberId = :memberId",
+                        LinkBundleEntity.class)
+                    .setParameter("memberId", member.getMemberId())
+                    .getSingleResult();
+                assertThat(linkBundleEntity.getDescription()).isEqualTo("기본");
+            });
         }
     }
 
@@ -77,12 +80,14 @@ class LinkBundleEventListenerTest extends BaseIntegrationTest {
             CreateHubResponse response = hubService.createHub(command);
 
             //then
-            LinkBundleEntity linkBundleEntity = em.createQuery(
-                    "select hlb from HubLinkBundleEntity hlb "
-                        + "where hlb.hub.hubId = :hubId", LinkBundleEntity.class)
-                .setParameter("hubId", response.hubId())
-                .getSingleResult();
-            assertThat(linkBundleEntity.getDescription()).isEqualTo("기본");
+            Awaitility.await().untilAsserted(() -> {
+                LinkBundleEntity linkBundleEntity = em.createQuery(
+                        "select hlb from HubLinkBundleEntity hlb "
+                            + "where hlb.hub.hubId = :hubId", LinkBundleEntity.class)
+                    .setParameter("hubId", response.hubId())
+                    .getSingleResult();
+                assertThat(linkBundleEntity.getDescription()).isEqualTo("기본");
+            });
         }
     }
 }

--- a/src/test/java/com/seong/shoutlink/global/event/TagEventListenerTest.java
+++ b/src/test/java/com/seong/shoutlink/global/event/TagEventListenerTest.java
@@ -3,6 +3,8 @@ package com.seong.shoutlink.global.event;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import com.seong.shoutlink.base.BaseIntegrationTest;
 import com.seong.shoutlink.domain.hub.Hub;
@@ -12,6 +14,7 @@ import com.seong.shoutlink.domain.link.link.Link;
 import com.seong.shoutlink.domain.link.link.repository.LinkEntity;
 import com.seong.shoutlink.domain.link.link.service.LinkUseCase;
 import com.seong.shoutlink.domain.link.link.service.request.CreateHubLinkCommand;
+import com.seong.shoutlink.domain.link.link.service.request.CreateLinkCommand;
 import com.seong.shoutlink.domain.link.linkbundle.LinkBundle;
 import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleEntity;
 import com.seong.shoutlink.domain.link.linkdomain.LinkDomain;
@@ -24,6 +27,7 @@ import com.seong.shoutlink.domain.tag.service.ai.GeneratedTag;
 import com.seong.shoutlink.fixture.HubFixture;
 import com.seong.shoutlink.fixture.LinkBundleFixture;
 import com.seong.shoutlink.fixture.MemberFixture;
+import com.seong.shoutlink.global.client.api.ApiException;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.stream.Stream;
@@ -107,6 +111,131 @@ class TagEventListenerTest extends BaseIntegrationTest {
                 assertThat(tags)
                     .extracting(TagEntity::getName)
                     .containsExactlyInAnyOrder("태그A", "태그B", "태그C");
+            });
+        }
+
+        @Test
+        @DisplayName("예외(apiException): apiException 발생시 3회까지 재시도 한다.")
+        void retry_whenApiException() {
+            //given
+            LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
+                new LinkDomain("github.com"));
+            Link link = new Link("https://github.com", "asdf");
+            persist(
+                linkDomainEntity,
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity)
+            );
+
+            CreateHubLinkCommand command = new CreateHubLinkCommand(
+                hubEntity.getHubId(),
+                memberEntity.getMemberId(),
+                linkBundleEntity.getLinkBundleId(),
+                "https://github.com/hseong3243",
+                "내 깃허브");
+
+            given(autoGenerativeClient.generateTags(any())).willThrow(ApiException.class);
+
+            //when
+            linkService.createHubLink(command);
+
+            //then
+            Awaitility.await().untilAsserted(() -> {
+                then(autoGenerativeClient).should(times(3)).generateTags(any());
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 링크 생성 이벤트 발생 시")
+    class MemberCreateLinkEvent_Published {
+
+
+        private MemberEntity memberEntity;
+        private LinkBundleEntity linkBundleEntity;
+
+        @BeforeEach
+        void setUp() {
+            Member member = MemberFixture.member();
+            LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+            memberEntity = MemberEntity.create(member);
+            linkBundleEntity = LinkBundleEntity.create(linkBundle, memberEntity);
+
+            persist(memberEntity, linkBundleEntity);
+        }
+
+        @Test
+        @DisplayName("성공: 허브 태그 자동 생성을 호출한다.")
+        void createHubTags() {
+            //given
+            LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
+                new LinkDomain("github.com"));
+            Link link = new Link("https://github.com", "asdf");
+            persist(
+                linkDomainEntity,
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity)
+            );
+
+            CreateLinkCommand command = new CreateLinkCommand(
+                memberEntity.getMemberId(),
+                linkBundleEntity.getLinkBundleId(),
+                "https://github.com/hseong3243",
+                "내 깃허브");
+            List<GeneratedTag> stubbedResponse = Stream.of("태그A", "태그B", "태그C")
+                .map(GeneratedTag::new)
+                .toList();
+
+            given(autoGenerativeClient.generateTags(any()))
+                .willReturn(stubbedResponse);
+
+            //when
+            linkService.createLink(command);
+
+            //then
+            Awaitility.await().untilAsserted(() -> {
+                List<TagEntity> tags = em.createQuery("select t from TagEntity t",
+                        TagEntity.class)
+                    .getResultList();
+                assertThat(tags)
+                    .extracting(TagEntity::getName)
+                    .containsExactlyInAnyOrder("태그A", "태그B", "태그C");
+            });
+        }
+
+        @Test
+        @DisplayName("예외(apiException): apiException 발생시 3회까지 재시도 한다.")
+        void retry_whenApiException() {
+            //given
+            LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
+                new LinkDomain("github.com"));
+            Link link = new Link("https://github.com", "asdf");
+            persist(
+                linkDomainEntity,
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity)
+            );
+
+            CreateLinkCommand command = new CreateLinkCommand(
+                memberEntity.getMemberId(),
+                linkBundleEntity.getLinkBundleId(),
+                "https://github.com/hseong3243",
+                "내 깃허브");
+
+            given(autoGenerativeClient.generateTags(any())).willThrow(ApiException.class);
+
+            //when
+            linkService.createLink(command);
+
+            //then
+            Awaitility.await().untilAsserted(() -> {
+                then(autoGenerativeClient).should(times(3)).generateTags(any());
             });
         }
     }

--- a/src/test/java/com/seong/shoutlink/global/event/TagEventListenerTest.java
+++ b/src/test/java/com/seong/shoutlink/global/event/TagEventListenerTest.java
@@ -1,0 +1,113 @@
+package com.seong.shoutlink.global.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.seong.shoutlink.base.BaseIntegrationTest;
+import com.seong.shoutlink.domain.hub.Hub;
+import com.seong.shoutlink.domain.hub.repository.HubEntity;
+import com.seong.shoutlink.domain.hub.repository.HubMemberEntity;
+import com.seong.shoutlink.domain.link.link.Link;
+import com.seong.shoutlink.domain.link.link.repository.LinkEntity;
+import com.seong.shoutlink.domain.link.link.service.LinkUseCase;
+import com.seong.shoutlink.domain.link.link.service.request.CreateHubLinkCommand;
+import com.seong.shoutlink.domain.link.linkbundle.LinkBundle;
+import com.seong.shoutlink.domain.link.linkbundle.repository.LinkBundleEntity;
+import com.seong.shoutlink.domain.link.linkdomain.LinkDomain;
+import com.seong.shoutlink.domain.link.linkdomain.repository.LinkDomainEntity;
+import com.seong.shoutlink.domain.member.Member;
+import com.seong.shoutlink.domain.member.repository.MemberEntity;
+import com.seong.shoutlink.domain.tag.repository.TagEntity;
+import com.seong.shoutlink.domain.tag.service.AutoGenerativeClient;
+import com.seong.shoutlink.domain.tag.service.ai.GeneratedTag;
+import com.seong.shoutlink.fixture.HubFixture;
+import com.seong.shoutlink.fixture.LinkBundleFixture;
+import com.seong.shoutlink.fixture.MemberFixture;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class TagEventListenerTest extends BaseIntegrationTest {
+
+    @MockBean
+    private AutoGenerativeClient autoGenerativeClient;
+
+    @Autowired
+    private LinkUseCase linkService;
+
+    @Autowired
+    private EntityManager em;
+
+    @Nested
+    @DisplayName("허브 링크 생성 이벤트 발행 시")
+    class CreateHubLinkEvent_Published {
+
+        private MemberEntity memberEntity;
+        private HubEntity hubEntity;
+        private HubMemberEntity hubMemberEntity;
+        private LinkBundleEntity linkBundleEntity;
+
+        @BeforeEach
+        void setUp() {
+            Member member = MemberFixture.member();
+            Hub hub = HubFixture.hub(member);
+            LinkBundle linkBundle = LinkBundleFixture.linkBundle();
+            memberEntity = MemberEntity.create(member);
+            hubEntity = HubEntity.create(hub);
+            hubMemberEntity = HubMemberEntity.create(memberEntity, hubEntity);
+            linkBundleEntity = LinkBundleEntity.create(linkBundle, hubEntity);
+
+            persist(memberEntity, hubEntity, hubMemberEntity, linkBundleEntity);
+        }
+
+        @Test
+        @DisplayName("성공: 허브 태그 자동 생성을 호출한다.")
+        void createHubTags() {
+            //given
+            LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
+                new LinkDomain("github.com"));
+            Link link = new Link("https://github.com", "asdf");
+            persist(
+                linkDomainEntity,
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
+                LinkEntity.create(link, linkBundleEntity, linkDomainEntity)
+            );
+
+            CreateHubLinkCommand command = new CreateHubLinkCommand(
+                hubEntity.getHubId(),
+                memberEntity.getMemberId(),
+                linkBundleEntity.getLinkBundleId(),
+                "https://github.com/hseong3243",
+                "내 깃허브");
+            List<GeneratedTag> stubbedResponse = Stream.of("태그A", "태그B", "태그C")
+                .map(GeneratedTag::new)
+                .toList();
+
+            given(autoGenerativeClient.generateTags(any()))
+                .willReturn(stubbedResponse);
+
+            //when
+            linkService.createHubLink(command);
+
+            //then
+            Awaitility.await().untilAsserted(() -> {
+                List<TagEntity> tags = em.createQuery("select t from TagEntity t",
+                        TagEntity.class)
+                    .getResultList();
+                assertThat(tags)
+                    .extracting(TagEntity::getName)
+                    .containsExactlyInAnyOrder("태그A", "태그B", "태그C");
+            });
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,6 +9,11 @@ gemini:
   url: https://generativelanguage.fake.com/v1/models/fake-pro:generateContent
   api-key: fakeAPIKey
 
+retry:
+  delay: 100
+  multiply: 1.0
+  max-attempt: 3
+
 spring:
   jpa:
     properties:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,7 +6,7 @@ jwt:
   refresh-secret: cjOYckwZQhEqZOCZCCjCIG4W0HFPfSjMtest
 
 gemini:
-  url: https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent
+  url: https://generativelanguage.fake.com/v1/models/fake-pro:generateContent
   api-key: fakeAPIKey
 
 spring:
@@ -15,3 +15,6 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+logging:
+  level:
+    com: debug


### PR DESCRIPTION
## 작업 내용

- 이벤트 리스너가 비동기적으로 작동되도록 변경하였습니다.
- 비동기 테스트를 위해 awaitility를 추가하였습니다.
- 사용자가 직접적으로 사용할 수 없는 기능인 태그 자동 생성은 실패시 다시 호출합니다.
  - 처음에는 성공, 실패 여부를 기록하기 위해 별도의 엔티티를 추가하고 스케줄러를 이용하려고 하였으나, spring-event가 더 적절한 듯 하여 이를 이용하였습니다.
  - ApiException이 발생한 경우 60초, 120초 간격으로 3회 시도하며 실패 시 error 로그를 기록하고 예외를 던집니다.
- 비동기 처리 실패 시 warn 로그를 기록하고 종료합니다.