### PR TITLE
Feat: 사용자는 링크 만료일을 선택할 수 있다.

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/link/link/Link.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/Link.java
@@ -1,5 +1,6 @@
 package com.seong.shoutlink.domain.link.link;
 
+import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
@@ -8,15 +9,17 @@ public class Link {
     private final Long linkId;
     private final String url;
     private final String description;
+    private final LocalDateTime expiredAt;
 
 
-    public Link(String url, String description) {
-        this(null, url, description);
+    public Link(String url, String description, LocalDateTime expiredAt) {
+        this(null, url, description, expiredAt);
     }
 
-    public Link(Long linkId, String url, String description) {
+    public Link(Long linkId, String url, String description, LocalDateTime expiredAt) {
         this.linkId = linkId;
         this.url = url;
         this.description = description;
+        this.expiredAt = expiredAt;
     }
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/link/controller/LinkController.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/controller/LinkController.java
@@ -43,7 +43,8 @@ public class LinkController {
             memberId,
             request.linkBundleId(),
             request.url(),
-            request.description()));
+            request.description(),
+            request.expiredAt()));
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -69,7 +70,8 @@ public class LinkController {
             memberId,
             request.linkBundleId(),
             request.url(),
-            request.description()));
+            request.description(),
+            request.expiredAt()));
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/seong/shoutlink/domain/link/link/controller/request/CreateLinkRequest.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/controller/request/CreateLinkRequest.java
@@ -2,12 +2,14 @@ package com.seong.shoutlink.domain.link.link.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 public record CreateLinkRequest(
     @NotNull(message = "링크 묶음 ID는 필수값입니다.")
     Long linkBundleId,
     @NotBlank(message = "링크 url은 필수값입니다.")
     String url,
-    String description) {
+    String description,
+    LocalDateTime expiredAt) {
 
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/link/repository/LinkEntity.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/repository/LinkEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,9 @@ public class LinkEntity extends BaseEntity {
     @Column
     private String description;
 
+    @Column
+    private LocalDateTime expiredAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "link_bundle_id", nullable = false)
     private LinkBundleEntity linkBundle;
@@ -41,10 +45,12 @@ public class LinkEntity extends BaseEntity {
     @JoinColumn(name = "link_domain_id", nullable = false, updatable = false)
     private LinkDomainEntity linkDomain;
 
-    private LinkEntity(String url, String description, LinkBundleEntity linkBundleEntity,
+    private LinkEntity(String url, String description, LocalDateTime expiredAt,
+        LinkBundleEntity linkBundleEntity,
         LinkDomainEntity linkDomainEntity) {
         this.url = url;
         this.description = description;
+        this.expiredAt = expiredAt;
         this.linkBundle = linkBundleEntity;
         this.linkDomain = linkDomainEntity;
     }
@@ -56,12 +62,13 @@ public class LinkEntity extends BaseEntity {
         return new LinkEntity(
             link.getUrl(),
             link.getDescription(),
+            link.getExpiredAt(),
             linkBundleEntity,
             linkDomainEntity);
     }
 
     public Link toDomain() {
-        return new Link(linkId, url, description);
+        return new Link(linkId, url, description, expiredAt);
     }
 
     public Long getLinkBundleId() {

--- a/src/main/java/com/seong/shoutlink/domain/link/link/service/LinkService.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/service/LinkService.java
@@ -47,7 +47,7 @@ public class LinkService implements LinkUseCase {
     public CreateLinkResponse createLink(CreateLinkCommand command) {
         Member member = getMember(command.memberId());
         LinkBundle linkBundle = getLinkBundle(command.linkBundleId(), member);
-        Link link = new Link(command.url(), command.description());
+        Link link = new Link(command.url(), command.description(), command.expiredAt());
         LinkBundleAndLink linkBundleAndLink = new LinkBundleAndLink(link, linkBundle);
         Long linkId = linkRepository.save(linkBundleAndLink);
         eventPublisher.publishEvent(
@@ -85,7 +85,7 @@ public class LinkService implements LinkUseCase {
         hub.checkMasterAuthority(member);
 
         LinkBundle hubLinkBundle = getHubLinkBundle(command.linkBundleId(), hub);
-        Link link = new Link(command.url(), command.description());
+        Link link = new Link(command.url(), command.description(), command.expiredAt());
         Long linkId = linkRepository.save(new LinkBundleAndLink(link, hubLinkBundle));
         eventPublisher.publishEvent(new CreateHubLinkEvent(linkId, link.getUrl(), hub.getHubId()));
         return new CreateHubLinkResponse(linkId);

--- a/src/main/java/com/seong/shoutlink/domain/link/link/service/request/CreateHubLinkCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/service/request/CreateHubLinkCommand.java
@@ -1,10 +1,13 @@
 package com.seong.shoutlink.domain.link.link.service.request;
 
+import java.time.LocalDateTime;
+
 public record CreateHubLinkCommand(
     Long hubId,
     Long memberId,
     Long linkBundleId,
     String url,
-    String description) {
+    String description,
+    LocalDateTime expiredAt) {
 
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/link/service/request/CreateLinkCommand.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/service/request/CreateLinkCommand.java
@@ -1,5 +1,8 @@
 package com.seong.shoutlink.domain.link.link.service.request;
 
-public record CreateLinkCommand(Long memberId, Long linkBundleId, String url, String description) {
+import java.time.LocalDateTime;
+
+public record CreateLinkCommand(Long memberId, Long linkBundleId, String url, String description,
+                                LocalDateTime expiredAt) {
 
 }

--- a/src/main/java/com/seong/shoutlink/domain/link/link/service/response/FindLinkResponse.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/service/response/FindLinkResponse.java
@@ -1,10 +1,11 @@
 package com.seong.shoutlink.domain.link.link.service.response;
 
 import com.seong.shoutlink.domain.link.link.Link;
+import java.time.LocalDateTime;
 
-public record FindLinkResponse(Long linkId, String url, String description) {
+public record FindLinkResponse(Long linkId, String url, String description, LocalDateTime expiredAt) {
 
     public static FindLinkResponse from(Link link) {
-        return new FindLinkResponse(link.getLinkId(), link.getUrl(), link.getDescription());
+        return new FindLinkResponse(link.getLinkId(), link.getUrl(), link.getDescription(), link.getExpiredAt());
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/link/controller/LinkControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/controller/LinkControllerTest.java
@@ -22,6 +22,7 @@ import com.seong.shoutlink.domain.link.link.service.response.CreateLinkResponse;
 import com.seong.shoutlink.domain.link.link.service.response.DeleteLinkResponse;
 import com.seong.shoutlink.domain.link.link.service.response.FindLinkResponse;
 import com.seong.shoutlink.domain.link.link.service.response.FindLinksResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ class LinkControllerTest extends BaseControllerTest {
     void createLink() throws Exception {
         //given
         CreateLinkRequest request = new CreateLinkRequest(1L, "https://hseong.tistory.com/",
-            "내 블로그");
+            "내 블로그", LocalDateTime.of(2050, 10, 10, 10, 10));
         CreateLinkResponse response = new CreateLinkResponse(1L);
         given(linkService.createLink(any())).willReturn(response);
 
@@ -59,7 +60,8 @@ class LinkControllerTest extends BaseControllerTest {
                         .description("링크 묶음 ID"),
                     fieldWithPath("url").type(JsonFieldType.STRING).description("링크 url"),
                     fieldWithPath("description").type(JsonFieldType.STRING).description("링크 설명")
-                        .optional()
+                        .optional(),
+                    fieldWithPath("expiredAt").type(JsonFieldType.STRING).description("만료일")
                 ),
                 responseFields(
                     fieldWithPath("linkId").type(JsonFieldType.NUMBER).description("생성된 링크 ID")
@@ -115,7 +117,8 @@ class LinkControllerTest extends BaseControllerTest {
     void createHubLink() throws Exception {
         //given
         Long hubId = 1L;
-        CreateLinkRequest request = new CreateLinkRequest(1L, "url", "설명");
+        CreateLinkRequest request = new CreateLinkRequest(1L, "url", "설명",
+            LocalDateTime.of(2050, 10, 10, 10, 10));
 
         given(linkService.createHubLink(any())).willReturn(new CreateHubLinkResponse(1L));
 
@@ -138,7 +141,8 @@ class LinkControllerTest extends BaseControllerTest {
                     fieldWithPath("linkBundleId").type(JsonFieldType.NUMBER)
                         .description("링크 묶음 ID"),
                     fieldWithPath("url").type(JsonFieldType.STRING).description("링크 url"),
-                    fieldWithPath("description").type(JsonFieldType.STRING).description("설명")
+                    fieldWithPath("description").type(JsonFieldType.STRING).description("설명"),
+                    fieldWithPath("expiredAt").type(JsonFieldType.STRING).description("만료일")
                 ),
                 responseFields(
                     fieldWithPath("linkId").type(JsonFieldType.NUMBER).description("링크 ID")

--- a/src/test/java/com/seong/shoutlink/domain/link/controller/LinkControllerTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/controller/LinkControllerTest.java
@@ -22,6 +22,7 @@ import com.seong.shoutlink.domain.link.link.service.response.CreateLinkResponse;
 import com.seong.shoutlink.domain.link.link.service.response.DeleteLinkResponse;
 import com.seong.shoutlink.domain.link.link.service.response.FindLinkResponse;
 import com.seong.shoutlink.domain.link.link.service.response.FindLinksResponse;
+import com.seong.shoutlink.fixture.LinkFixture;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -77,7 +78,8 @@ class LinkControllerTest extends BaseControllerTest {
         params.add("linkBundleId", "1");
         params.add("page", "0");
         params.add("size", "10");
-        FindLinkResponse findLinkResponse = new FindLinkResponse(1L, "url", "간단한 설명");
+        FindLinkResponse findLinkResponse = new FindLinkResponse(1L, "url", "간단한 설명",
+            LinkFixture.DEFAULT_EXPIRED_AT);
         FindLinksResponse response = new FindLinksResponse(List.of(findLinkResponse), 1,
             false);
 
@@ -105,6 +107,7 @@ class LinkControllerTest extends BaseControllerTest {
                     fieldWithPath("links[].url").type(JsonFieldType.STRING).description("링크 url"),
                     fieldWithPath("links[].description").type(JsonFieldType.STRING)
                         .description("링크 설명"),
+                    fieldWithPath("links[].expiredAt").type(JsonFieldType.STRING).description("링크 만료일"),
                     fieldWithPath("totalElements").type(JsonFieldType.NUMBER)
                         .description("총 요소 개수"),
                     fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부")
@@ -159,7 +162,8 @@ class LinkControllerTest extends BaseControllerTest {
         params.add("page", "0");
         params.add("size", "20");
         long hubId = 1;
-        FindLinkResponse findLink = new FindLinkResponse(1L, "url", "설명");
+        FindLinkResponse findLink = new FindLinkResponse(1L, "url", "설명",
+            LinkFixture.DEFAULT_EXPIRED_AT);
         FindLinksResponse response = new FindLinksResponse(List.of(findLink), 1, false);
 
         given(linkService.findHubLinks(any())).willReturn(response);
@@ -189,6 +193,7 @@ class LinkControllerTest extends BaseControllerTest {
                     fieldWithPath("links[].url").type(JsonFieldType.STRING).description("링크 url"),
                     fieldWithPath("links[].description").type(JsonFieldType.STRING)
                         .description("링크 설명"),
+                    fieldWithPath("links[].expiredAt").type(JsonFieldType.STRING).description("링크 만료일"),
                     fieldWithPath("totalElements").type(JsonFieldType.NUMBER)
                         .description("총 요소 개수"),
                     fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부")

--- a/src/test/java/com/seong/shoutlink/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/service/LinkServiceTest.java
@@ -74,7 +74,8 @@ class LinkServiceTest {
                 1L,
                 linkBundle.getLinkBundleId(),
                 "https://hseong.tistory.com/",
-                "내 블로그");
+                "내 블로그",
+                LinkFixture.DEFAULT_EXPIRED_AT);
 
             //when
             CreateLinkResponse response = linkService.createLink(command);
@@ -95,7 +96,8 @@ class LinkServiceTest {
                 1L,
                 linkBundle.getLinkBundleId(),
                 "https://hseong.tistory.com/",
-                "내 블로그");
+                "내 블로그",
+                LinkFixture.DEFAULT_EXPIRED_AT);
 
             //when
             CreateLinkResponse response = linkService.createLink(command);
@@ -166,7 +168,8 @@ class LinkServiceTest {
             linkBundleRepository.stub(linkBundle);
             hubRepository.stub(hub);
             CreateHubLinkCommand command = new CreateHubLinkCommand(hub.getHubId(),
-                hub.getMasterId(), linkBundle.getLinkBundleId(), "url", "설명");
+                hub.getMasterId(), linkBundle.getLinkBundleId(), "url", "설명",
+                LinkFixture.DEFAULT_EXPIRED_AT);
 
             //when
             CreateHubLinkResponse response = linkService.createHubLink(command);
@@ -186,7 +189,8 @@ class LinkServiceTest {
             linkBundleRepository.stub(linkBundle);
             hubRepository.stub(hub);
             CreateHubLinkCommand command = new CreateHubLinkCommand(hub.getHubId(),
-                hub.getMasterId(), linkBundle.getLinkBundleId(), "url", "설명");
+                hub.getMasterId(), linkBundle.getLinkBundleId(), "url", "설명",
+                LinkFixture.DEFAULT_EXPIRED_AT);
 
             //when
             CreateHubLinkResponse response = linkService.createHubLink(command);
@@ -199,7 +203,8 @@ class LinkServiceTest {
         @DisplayName("예외(NotFound): 존재하지 않는 허브")
         void notFound_WhenHubNotFound() {
             //given
-            CreateHubLinkCommand command = new CreateHubLinkCommand(1L, 1L, 1L, "url", "설명");
+            CreateHubLinkCommand command = new CreateHubLinkCommand(1L, 1L, 1L, "url", "설명",
+                LinkFixture.DEFAULT_EXPIRED_AT);
 
             //when
             Exception exception = catchException(() -> linkService.createHubLink(command));
@@ -219,7 +224,7 @@ class LinkServiceTest {
             memberRepository.stub(member);
             hubRepository.stub(hub);
             CreateHubLinkCommand command = new CreateHubLinkCommand(hub.getHubId(),
-                member.getMemberId(), 1L, "url", "설명");
+                member.getMemberId(), 1L, "url", "설명", LinkFixture.DEFAULT_EXPIRED_AT);
 
             //when
             Exception exception = catchException(() -> linkService.createHubLink(command));
@@ -242,7 +247,7 @@ class LinkServiceTest {
             memberRepository.stub(member);
             hubRepository.stub(hub);
             CreateHubLinkCommand command = new CreateHubLinkCommand(hub.getHubId(),
-                member.getMemberId(), 1L, "url", "설명");
+                member.getMemberId(), 1L, "url", "설명", LinkFixture.DEFAULT_EXPIRED_AT);
 
             //when
             Exception exception = catchException(() -> linkService.createHubLink(command));

--- a/src/test/java/com/seong/shoutlink/fixture/LinkFixture.java
+++ b/src/test/java/com/seong/shoutlink/fixture/LinkFixture.java
@@ -1,6 +1,7 @@
 package com.seong.shoutlink.fixture;
 
 import com.seong.shoutlink.domain.link.link.Link;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,15 +10,20 @@ public final class LinkFixture {
     public static final long LINK_ID = 1L;
     public static final String URL = "https://github.com/hseong3243";
     public static final String DESCRIPTION = "관심있는 곳";
+    public static final LocalDateTime DEFAULT_EXPIRED_AT = LocalDateTime.of(2050, 10, 10, 10, 10);
 
     public static Link link() {
-        return new Link(LINK_ID, URL, DESCRIPTION);
+        return new Link(LINK_ID, URL, DESCRIPTION, DEFAULT_EXPIRED_AT);
+    }
+
+    public static Link link(LocalDateTime expiredAt) {
+        return new Link(LINK_ID, URL, DESCRIPTION, expiredAt);
     }
 
     public static List<Link> links(int count) {
         List<Link> links = new ArrayList<>();
         for(int i=1; i<=count; i++) {
-            links.add(new Link((long) i, URL, DESCRIPTION));
+            links.add(new Link((long) i, URL, DESCRIPTION, DEFAULT_EXPIRED_AT));
         }
         return links;
     }

--- a/src/test/java/com/seong/shoutlink/global/event/TagEventListenerTest.java
+++ b/src/test/java/com/seong/shoutlink/global/event/TagEventListenerTest.java
@@ -26,6 +26,7 @@ import com.seong.shoutlink.domain.tag.service.AutoGenerativeClient;
 import com.seong.shoutlink.domain.tag.service.ai.GeneratedTag;
 import com.seong.shoutlink.fixture.HubFixture;
 import com.seong.shoutlink.fixture.LinkBundleFixture;
+import com.seong.shoutlink.fixture.LinkFixture;
 import com.seong.shoutlink.fixture.MemberFixture;
 import com.seong.shoutlink.global.client.api.ApiException;
 import jakarta.persistence.EntityManager;
@@ -78,7 +79,7 @@ class TagEventListenerTest extends BaseIntegrationTest {
             //given
             LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
                 new LinkDomain("github.com"));
-            Link link = new Link("https://github.com", "asdf");
+            Link link = new Link("https://github.com", "asdf", LinkFixture.DEFAULT_EXPIRED_AT);
             persist(
                 linkDomainEntity,
                 LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
@@ -92,7 +93,8 @@ class TagEventListenerTest extends BaseIntegrationTest {
                 memberEntity.getMemberId(),
                 linkBundleEntity.getLinkBundleId(),
                 "https://github.com/hseong3243",
-                "내 깃허브");
+                "내 깃허브",
+                LinkFixture.DEFAULT_EXPIRED_AT);
             List<GeneratedTag> stubbedResponse = Stream.of("태그A", "태그B", "태그C")
                 .map(GeneratedTag::new)
                 .toList();
@@ -120,7 +122,7 @@ class TagEventListenerTest extends BaseIntegrationTest {
             //given
             LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
                 new LinkDomain("github.com"));
-            Link link = new Link("https://github.com", "asdf");
+            Link link = new Link("https://github.com", "asdf", LinkFixture.DEFAULT_EXPIRED_AT);
             persist(
                 linkDomainEntity,
                 LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
@@ -134,7 +136,7 @@ class TagEventListenerTest extends BaseIntegrationTest {
                 memberEntity.getMemberId(),
                 linkBundleEntity.getLinkBundleId(),
                 "https://github.com/hseong3243",
-                "내 깃허브");
+                "내 깃허브", LinkFixture.DEFAULT_EXPIRED_AT);
 
             given(autoGenerativeClient.generateTags(any())).willThrow(ApiException.class);
 
@@ -172,7 +174,7 @@ class TagEventListenerTest extends BaseIntegrationTest {
             //given
             LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
                 new LinkDomain("github.com"));
-            Link link = new Link("https://github.com", "asdf");
+            Link link = new Link("https://github.com", "asdf", LinkFixture.DEFAULT_EXPIRED_AT);
             persist(
                 linkDomainEntity,
                 LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
@@ -185,7 +187,7 @@ class TagEventListenerTest extends BaseIntegrationTest {
                 memberEntity.getMemberId(),
                 linkBundleEntity.getLinkBundleId(),
                 "https://github.com/hseong3243",
-                "내 깃허브");
+                "내 깃허브", LinkFixture.DEFAULT_EXPIRED_AT);
             List<GeneratedTag> stubbedResponse = Stream.of("태그A", "태그B", "태그C")
                 .map(GeneratedTag::new)
                 .toList();
@@ -213,7 +215,7 @@ class TagEventListenerTest extends BaseIntegrationTest {
             //given
             LinkDomainEntity linkDomainEntity = LinkDomainEntity.create(
                 new LinkDomain("github.com"));
-            Link link = new Link("https://github.com", "asdf");
+            Link link = new Link("https://github.com", "asdf", LinkFixture.DEFAULT_EXPIRED_AT);
             persist(
                 linkDomainEntity,
                 LinkEntity.create(link, linkBundleEntity, linkDomainEntity),
@@ -226,7 +228,7 @@ class TagEventListenerTest extends BaseIntegrationTest {
                 memberEntity.getMemberId(),
                 linkBundleEntity.getLinkBundleId(),
                 "https://github.com/hseong3243",
-                "내 깃허브");
+                "내 깃허브", LinkFixture.DEFAULT_EXPIRED_AT);
 
             given(autoGenerativeClient.generateTags(any())).willThrow(ApiException.class);
 


### PR DESCRIPTION
## 작업 내용

- 링크 엔티티에 만료일 필드를 추가하였습니다.
  - 만료일이 null 인 경우 9999년 12월 31일 23시 59분을 기본값으로 합니다.
- 링크 생성, 응답 dto에 만료일 필드를 추가하였습니다.