### PR TITLE
Fix: 링크 만료일 기본값을 추가한다. 

### DIFF
--- a/src/main/java/com/seong/shoutlink/domain/link/link/Link.java
+++ b/src/main/java/com/seong/shoutlink/domain/link/link/Link.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 @Getter
 public class Link {
 
+    private static final LocalDateTime NO_EXPIRED_DATE_TIME =
+        LocalDateTime.of(9999, 12, 31, 23, 59);
+
     private final Long linkId;
     private final String url;
     private final String description;
@@ -20,6 +23,6 @@ public class Link {
         this.linkId = linkId;
         this.url = url;
         this.description = description;
-        this.expiredAt = expiredAt;
+        this.expiredAt = expiredAt != null ? expiredAt : NO_EXPIRED_DATE_TIME;
     }
 }

--- a/src/test/java/com/seong/shoutlink/domain/link/link/LinkTest.java
+++ b/src/test/java/com/seong/shoutlink/domain/link/link/LinkTest.java
@@ -1,0 +1,53 @@
+package com.seong.shoutlink.domain.link.link;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LinkTest {
+
+    @Nested
+    @DisplayName("링크 생성 시")
+    class CreateLink {
+
+        String url;
+        String description;
+
+        @BeforeEach
+        void setUp() {
+            url = "github.ocm";
+            description = "깃허브";
+        }
+
+        @Test
+        @DisplayName("성공: 만료일이 null이면 기본값은 9999년 12월 31일 23시 59분이다.")
+        void createLink_WhenExpiredAtIsNull_ThenDefaultExpiredAt_9999_12_31_23_59() {
+            //given
+            LocalDateTime expiredAt = null;
+
+            //when
+            Link link = new Link(url, description, expiredAt);
+
+            //then
+            assertThat(link.getExpiredAt()).isEqualToIgnoringSeconds(
+                LocalDateTime.of(9999, 12, 31, 23, 59));
+        }
+
+        @Test
+        @DisplayName("성공: 만료일이 null이 아니면 입력값을 따른다.")
+        void createLink_WhenExpiredAtIsNotNull_ThenFollowInput() {
+            //given
+            LocalDateTime expiredAt = LocalDateTime.of(2024, 12, 31, 23, 59);
+
+            //when
+            Link link = new Link(url, description, expiredAt);
+
+            //when
+            assertThat(link.getExpiredAt()).isEqualToIgnoringSeconds(expiredAt);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 링크 엔티티 생성시 입력값이 null 인 경우의 기본 만료일 할당을 추가했습니다.